### PR TITLE
[WIP] [FEATURE] PHPCR wrapper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     "require-dev": {
         "symfony/symfony": "2.5.*",
         "phpunit/phpunit": "4.0.*",
+        "matthiasnoback/symfony-dependency-injection-test": "v0.7.1",
         "sulu/test-bundle": "dev-develop",
         "jackalope/jackalope-doctrine-dbal": "1.1.*"
     },

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Configuration.php
@@ -97,7 +97,15 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->arrayNode('backend')
                     ->useAttributeAsKey('name')
-                    ->prototype('variable')
+                    ->prototype('variable')->end()
+                ->end()
+                ->arrayNode('class_map')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('session')->defaultValue('Sulu\Component\PHPCR\Wrapper\Wrapped\Session')->end()
+                        ->scalarNode('node')->defaultValue('Sulu\Component\PHPCR\Wrapper\Wrapped\Node')->end()
+                        ->scalarNode('property')->defaultValue('Sulu\Component\PHPCR\Wrapper\Wrapped\Property')->end()
+                    ->end()
                 ->end()
             ->end();
     }

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -37,6 +37,7 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
 
         if (isset($config['phpcr'])) {
             $phpcrConfig = $config['phpcr'];
+            unset($phpcrConfig['class_map']);
 
             foreach ($container->getExtensions() as $name => $extension) {
                 $prependConfig = array();
@@ -139,6 +140,16 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
     private function initPhpcr($phpcrConfig, ContainerBuilder $container, Loader\XmlFileLoader $loader)
     {
         $loader->load('phpcr.xml');
+
+        $wrapperExtension = $container->getDefinition('sulu.phpcr.wrapper');
+        $classMap = array(
+            'PHPCR\NodeInterface' => $phpcrConfig['class_map']['node'],
+            'PHPCR\PropertyInterface' => $phpcrConfig['class_map']['property'],
+            'PHPCR\SessionInterface' => $phpcrConfig['class_map']['session'],
+        );
+        $wrapperExtension->setArguments(array($classMap));
+
+        $container->setParameter('sulu.phpcr.wrapped_session.class', $phpcrConfig['class_map']['session']);
     }
 
     /**

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/phpcr.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/phpcr.xml
@@ -5,11 +5,25 @@
 
     <parameters>
         <parameter key="sulu.phpcr.session.class">Sulu\Component\PHPCR\SessionManager\SessionManager</parameter>
+        <parameter key="sulu.phpcr.wrapped_session.class"><!-- Injected in extension from configuration --></parameter>
+        <parameter key="sulu.phpcr.wrapper.class">Sulu\Component\PHPCR\Wrapper\Wrapper\SimpleWrapper</parameter>
     </parameters>
 
     <services>
-        <service id="sulu.phpcr.session" class="%sulu.phpcr.session.class%">
+        <service id="sulu.phpcr.wrapper" class="%sulu.phpcr.wrapper.class%"/>
+
+        <service 
+            id="sulu.phpcr.wrapped_session" 
+            class="%sulu.phpcr.wrapped_session.class%"
+            factory-service="sulu.phpcr.wrapper"
+            factory-method="wrap"
+            >
             <argument type="service" id="doctrine_phpcr.default_session"/>
+            <argument>PHPCR\SessionInterface</argument>
+        </service>
+
+        <service id="sulu.phpcr.session" class="%sulu.phpcr.session.class%">
+            <argument type="service" id="sulu.phpcr.wrapped_session"/>
             <argument type="collection">
                 <argument key="base">%sulu.content.node_names.base%</argument>
                 <argument key="content">%sulu.content.node_names.content%</argument>

--- a/src/Sulu/Component/PHPCR/Wrapper/Exception/WrapperException.php
+++ b/src/Sulu/Component/PHPCR/Wrapper/Exception/WrapperException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Sulu\Component\PHPCR\Wrapper\Exception;
+
+class WrapperException extends \Exception
+{
+}

--- a/src/Sulu/Component/PHPCR/Wrapper/Traits/ItemTrait.php
+++ b/src/Sulu/Component/PHPCR/Wrapper/Traits/ItemTrait.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Sulu\Component\PHPCR\Wrapper\Traits;
+
+use PHPCR\ItemInterface;
+use PHPCR\ItemVisitorInterface;
+
+/**
+ * This trait fulfils the PHPCR\ItemInterface
+ *
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+trait ItemTrait
+{
+    use WrappedObjectTrait;
+    use WrapperAwareTrait;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getPath()
+    {
+        return $this->getWrappedObject()->getPath();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return $this->getWrappedObject()->getName();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAncestor($depth)
+    {
+        return $this->getWrappedObject()->getAncestor();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getParent()
+    {
+        return $this->getWrapper()->wrap($this->getWrappedObject()->getParent(), 'PHPCR\NodeInterface');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDepth()
+    {
+        return $this->getWrappedObject()->getDepth();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isNode()
+    {
+        return $this->getWrappedObject()->isNode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isNew()
+    {
+        return $this->getWrappedObject()->isNew();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isModified()
+    {
+        return $this->getWrappedObject()->isModified();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isSame(ItemInterface $otherItem)
+    {
+        return $this->getWrappedObject()->isSame($otherItem);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function accept(ItemVisitorInterface $visitor)
+    {
+        return $this->getWrappedObject()->accept();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function revert()
+    {
+        return $this->getWrappedObject()->revert();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function remove()
+    {
+        return $this->getWrappedObject()->remove();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getSession()
+    {
+        return $this->getWrapper()->wrap($this->getWrappedObject()->getSession(), 'PHPCR\SessionInterface');
+    }
+}

--- a/src/Sulu/Component/PHPCR/Wrapper/Traits/NodeTrait.php
+++ b/src/Sulu/Component/PHPCR/Wrapper/Traits/NodeTrait.php
@@ -1,0 +1,343 @@
+<?php
+
+namespace Sulu\Component\PHPCR\Wrapper\Traits;
+
+use PHPCR\ItemInterface;
+
+/**
+ * This trait fulfils the PHPCR\NodeInterface
+ *
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+trait NodeTrait
+{
+    use ItemTrait;
+
+    /**
+     * @see PHPCR\NodeInterface#addNode
+     */
+    public function addNode($relPath, $primaryNodeTypeName = null)
+    {
+        return $this->getWrapper()->wrap($this->call('addNode', func_get_args()), 'PHPCR\NodeInterface');
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#addNodeAutoNamed
+     */
+    public function addNodeAutoNamed($nameHint = null, $primaryNodeTypeName = null)
+    {
+        return $this->getWrapper()->wrap($this->call('addNodeAutoNamed', func_get_args()), 'PHPCR\NodeInterface');
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#orderBefore
+     */
+    public function orderBefore($srcChildRelPath, $destChildRelPath)
+    {
+        return $this->getWrappedObject()->orderBefore($srcChildRelPath, $destChildRelPath);
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#rename
+     */
+    public function rename($newName)
+    {
+        return $this->getWrappedObject()->rename($newName);
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#setProperty
+     */
+    public function setProperty($name, $value, $type = null)
+    {
+        return $this->call('setProperty', func_get_args());
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#getNode
+     */
+    public function getNode($relPath)
+    {
+        return $this->getWrapper()->wrap($this->getWrappedObject()->getNode($relPath), 'PHPCR\NodeInterface');
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#getNodes
+     */
+    public function getNodes($nameFilter = null, $typeFilter = null)
+    {
+        return $this->getWrapper()->wrapMany($this->call('getNodes', func_get_args()), 'PHPCR\NodeInterface');
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#getNodeNames
+     */
+    public function getNodeNames($nameFilter = null, $typeFilter = null)
+    {
+        return $this->call('getNodeNames', func_get_args());
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#getProperty
+     */
+    public function getProperty($relPath)
+    {
+        return $this->getWrapper()->wrap($this->getWrappedObject()->getProperty($relPath), 'PHPCR\PropertyInterface');
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#getPropertyValue
+     */
+    public function getPropertyValue($name, $type=null)
+    {
+        return $this->call('getPropertyValue', func_get_args());
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#getPropertyValueWithDefault
+     */
+    public function getPropertyValueWithDefault($relPath, $defaultValue)
+    {
+        return $this->getWrappedObject()->getPropertyValueWithDefault($relPath, $defaultValue);
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#getProperties
+     */
+    public function getProperties($nameFilter = null)
+    {
+        return $this->getWrapper()->wrapMany($this->call('getProperties', func_get_args()), 'PHPCR\PropertyInterface');
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#getPropertiesValues
+     */
+    public function getPropertiesValues($nameFilter=null, $dereference=true)
+    {
+        return $this->call('getPropertiesValues', func_get_args());
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#getPrimaryItem
+     */
+    public function getPrimaryItem()
+    {
+        return $this->getWrapper()->wrap($this->getWrappedObject()->getPrimaryItem(), 'PHPCR\ItemInterface');
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#getIdentifier
+     */
+    public function getIdentifier()
+    {
+        return $this->getWrappedObject()->getIdentifier();
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#getIndex
+     */
+    public function getIndex()
+    {
+        return $this->getWrappedObject()->getIndex();
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#getReferences
+     */
+    public function getReferences($name = null)
+    {
+        return $this->getWrapper()->wrapMany($this->call('getReferences', func_get_args()), 'PHPCR\PropertyInterface');
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#getWeakReferences
+     */
+    public function getWeakReferences($name = null)
+    {
+        return $this->getWrapper()->wrapMany($this->call('getWeakReferences', func_get_args()), 'PHPCR\PropertyInterface');
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#hasNode
+     */
+    public function hasNode($relPath)
+    {
+        return $this->getWrappedObject()->hasNode($relPath);
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#hasProperty
+     */
+    public function hasProperty($relPath)
+    {
+        return $this->getWrappedObject()->hasProperty($relPath);
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#hasNodes
+     */
+    public function hasNodes()
+    {
+        return $this->getWrappedObject()->hasNodes();
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#hasProperties
+     */
+    public function hasProperties()
+    {
+        return $this->getWrappedObject()->hasProperties();
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#getPrimaryNodeType
+     */
+    public function getPrimaryNodeType()
+    {
+        return $this->getWrapper()->wrap($this->getWrappedObject()->getPrimaryNodeType(), 'PHPCR\NodeType\NodeTypeInterface');
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#getMixinNodeTypes
+     */
+    public function getMixinNodeTypes()
+    {
+        return $this->getWrapper()->wrapMany($this->getWrappedObject()->getMixinNodeTypes(), 'PHPCR\NodeType\NodeTypeInterface');
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#isNodeType
+     */
+    public function isNodeType($nodeTypeName)
+    {
+        return $this->getWrappedObject()->isNodeType($nodeTypeName);
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#setPrimaryType
+     */
+    public function setPrimaryType($nodeTypeName)
+    {
+        return $this->getWrappedObject()->setPrimaryType($nodeTypeName);
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#addMixin
+     */
+    public function addMixin($mixinName)
+    {
+        return $this->getWrappedObject()->addMixin($mixinName);
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#removeMixin
+     */
+    public function removeMixin($mixinName)
+    {
+        return $this->getWrappedObject()->removeMixin($mixinName);
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#setMixins
+     */
+    public function setMixins(array $mixinNames)
+    {
+        return $this->getWrappedObject()->setMixins($mixinNames);
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#canAddMixin
+     */
+    public function canAddMixin($mixinName)
+    {
+        return $this->getWrappedObject()->canAddMixin($mixinName);
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#getDefinition
+     */
+    public function getDefinition()
+    {
+        return $this->getWrapper()->wrap($this->getWrappedObject()->getDefinition(), 'PHPCR\NodeType\NodeDefinitionInterface');
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#update
+     */
+    public function update($srcWorkspace)
+    {
+        return $this->getWrappedObject()->update($srcWorkspace);
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#getCorrespondingNodePath
+     */
+    public function getCorrespondingNodePath($workspaceName)
+    {
+        return $this->getWrappedObject()->getCorrespondingNodePath($workspaceName);
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#getSharedSet
+     */
+    public function getSharedSet()
+    {
+        return $this->getWrapper()->wrapMany($this->getWrappedObject()->getSharedSet(), 'PHPCR\NodeInterface');
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#removeSharedSet
+     */
+    public function removeSharedSet()
+    {
+        return $this->getWrappedObject()->removeSharedSet();
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#removeShare
+     */
+    public function removeShare()
+    {
+        return $this->getWrappedObject()->removeShare();
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#isCheckedOut
+     */
+    public function isCheckedOut()
+    {
+        return $this->getWrappedObject()->isCheckedOut();
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#isLocked
+     */
+    public function isLocked()
+    {
+        return $this->getWrappedObject()->isLocked();
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#followLifecycleTransition
+     */
+    public function followLifecycleTransition($transition)
+    {
+        return $this->getWrappedObject()->followLifecycleTransition($transition);
+    }
+
+    /**
+     * @see PHPCR\NodeInterface#getAllowedLifecycleTransitions
+     */
+    public function getAllowedLifecycleTransitions()
+    {
+        return $this->getWrappedObject()->getAllowedLifecycleTransitions();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getPath()
+    {
+        return $this->getWrappedObject()->getPath();
+    }
+}

--- a/src/Sulu/Component/PHPCR/Wrapper/Traits/PropertyTrait.php
+++ b/src/Sulu/Component/PHPCR/Wrapper/Traits/PropertyTrait.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Sulu\Component\PHPCR\Wrapper\Traits;
+
+/**
+ * This trait fulfils the PHPCR\PropertyInterface
+ *
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+trait PropertyTrait
+{
+    use ItemTrait;
+
+    public function setValue($value, $type = null)
+    {
+        return $this->call('setValue', func_get_args());
+    }
+
+    public function addValue($value)
+    {
+        return $this->call('addValue', func_get_args());
+    }
+
+    public function getValue()
+    {
+        return $this->call('getValue');
+    }
+
+    public function getString()
+    {
+        return $this->call('getString');
+    }
+
+    public function getBinary()
+    {
+        return $this->call('getBinary');
+    }
+
+    public function getLong()
+    {
+        return $this->call('getLong');
+    }
+
+    public function getDouble()
+    {
+        return $this->call('getDouble');
+    }
+
+    public function getDecimal()
+    {
+        return $this->call('getDecimal');
+    }
+
+    public function getDate()
+    {
+        return $this->call('getDate');
+    }
+
+    public function getBoolean()
+    {
+        return $this->call('getBoolean');
+    }
+
+    public function getNode()
+    {
+        return $this->getWrapper()->wrap($this->call('getNode'), 'PHPCR\NodeInterface');
+    }
+
+    public function getProperty()
+    {
+        return $this->getWrapper()->wrap($this->call('getProperty'), 'PHPCR\PropertyInterface');
+    }
+
+    public function getLength()
+    {
+        return $this->call('getLength');
+    }
+
+    public function getDefinition()
+    {
+        return $this->getWrapper()->wrap($this->call('getDefinition'), 'PHPCR\PropertyDefinitionInterface');
+    }
+
+    public function getType()
+    {
+        return $this->call('getType');
+    }
+
+    public function isMultiple()
+    {
+        return $this->call('isMultiple');
+    }
+}

--- a/src/Sulu/Component/PHPCR/Wrapper/Traits/SessionTrait.php
+++ b/src/Sulu/Component/PHPCR/Wrapper/Traits/SessionTrait.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace Sulu\Component\PHPCR\Wrapper\Traits;
+
+use PHPCR\ItemInterface;
+use PHPCR\CredentialsInterface;
+use PHPCR\PHPCR\NodeInterface;
+
+/**
+ * This trait fulfils the PHPCR\PHPCR\NodeInterface
+ *
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+trait SessionTrait
+{
+    use WrapperAwareTrait;
+    use WrappedObjectTrait;
+
+    public function getRepository()
+    {
+        return $this->getWrapper()->wrap($this->getWrappedObject()->getRepository(), 'PHPCR\RepositoryInterface');
+    }
+
+    public function getUserID()
+    {
+        return $this->getWrappedObject()->getUserID();
+    }
+
+    public function getAttributeNames()
+    {
+        return $this->getWrappedObject()->getAttributeNames();
+    }
+
+    public function getAttribute($name)
+    {
+        return $this->getWrappedObject()->getAttribute($name);
+    }
+
+    public function getWorkspace()
+    {
+        return $this->getWrapper()->wrap($this->getWrappedObject()->getWorkspace(), 'PHPCR\WorkspaceInterface');
+    }
+
+    public function getRootNode()
+    {
+        return $this->getWrapper()->wrap($this->getWrappedObject()->getRootNode(), 'PHPCR\NodeInterface');
+    }
+
+    public function impersonate(CredentialsInterface $credentials)
+    {
+        return $this->getWrappedObject()->impersonate($credentials);
+    }
+
+    public function getNodeByIdentifier($id)
+    {
+        return $this->getWrapper()->wrap($this->getWrappedObject()->getNodeByIdentifier($id), 'PHPCR\NodeInterface');
+    }
+
+    public function getNodesByIdentifier($ids)
+    {
+        return $this->getWrapper()->wrapMany($this->getWrappedObject()->getNodesByIdentifier($ids), 'PHPCR\NodeInterface');
+    }
+
+    public function getItem($path)
+    {
+        return $this->getWrapper()->wrap($this->getWrappedObject()->getItem($path), 'PHPCR\ItemInterface');
+    }
+
+    public function getNode($path, $depthHint = -1)
+    {
+        return $this->getWrapper()->wrap($this->getWrappedObject()->getNode($path), 'PHPCR\NodeInterface');
+    }
+
+    public function getNodes($paths)
+    {
+        return $this->getWrapper()->wrapMany($this->getWrappedObject()->getNodes($paths), 'PHPCR\NodeInterface');
+    }
+
+    public function getProperty($path)
+    {
+        return $this->getWrapper()->wrap($this->getWrappedObject()->getProperty($path), 'PHPCR\PropertyInterface');
+    }
+
+    public function getProperties($paths)
+    {
+        return $this->getWrapper()->wrapMany($this->getWrappedObject()->getProperties($paths), 'PHPCR\PropertyInterface');
+    }
+
+    public function itemExists($path)
+    {
+        return $this->getWrappedObject()->itemExists($path);
+    }
+
+    public function nodeExists($path)
+    {
+        return $this->getWrappedObject()->nodeExists($path);
+    }
+
+    public function propertyExists($path)
+    {
+        return $this->getWrappedObject()->propertyExists($path);
+    }
+
+    public function move($srcAbsPath, $destAbsPath)
+    {
+        return $this->getWrappedObject()->move($srcAbsPath, $destAbsPath);
+    }
+
+    public function removeItem($path)
+    {
+        return $this->getWrappedObject()->removeItem($path);
+    }
+
+    public function save()
+    {
+        return $this->getWrappedObject()->save();
+    }
+
+    public function refresh($keepChanges)
+    {
+        return $this->getWrappedObject()->refresh($keepChanges);
+    }
+
+    public function hasPendingChanges()
+    {
+        return $this->getWrappedObject()->hasPendingChanges();
+    }
+
+    public function hasPermission($path, $actions)
+    {
+        return $this->getWrappedObject()->hasPermission($path, $actions);
+    }
+
+    public function checkPermission($path, $actions)
+    {
+        return $this->getWrappedObject()->checkPermission($path, $actions);
+    }
+
+    public function hasCapability($methodName, $target, array $arguments)
+    {
+        return $this->getWrappedObject()->hasCapability($methodName, $target, $arguments);
+    }
+
+    public function importXML($parentAbsPath, $uri, $uuidBehavior)
+    {
+        return $this->getWrappedObject()->importXML($parentAbsPath, $uri, $uuidBehavior);
+    }
+
+    public function exportSystemView($path, $stream, $skipBinary, $noRecurse)
+    {
+        return $this->getWrappedObject()->exportSystemView($path, $stream, $skipBinary, $noRecurse);
+    }
+
+    public function exportDocumentView($path, $stream, $skipBinary, $noRecurse)
+    {
+        return $this->getWrappedObject()->exportDocumentView($path, $stream, $skipBinary, $noRecurse);
+    }
+
+    public function setNamespacePrefix($prefix, $uri)
+    {
+        return $this->getWrappedObject()->setNamespacePrefix($prefix, $uri);
+    }
+
+    public function getNamespacePrefixes()
+    {
+        return $this->getWrappedObject()->getNamespacePrefixes();
+    }
+
+    public function getNamespaceURI($prefix)
+    {
+        return $this->getWrappedObject()->getNamespaceURI($prefix);
+    }
+
+    public function getNamespacePrefix($uri)
+    {
+        return $this->getWrappedObject()->getNamespacePrefix($uri);
+    }
+
+    public function logout()
+    {
+        return $this->getWrappedObject()->logout();
+    }
+
+    public function isLive()
+    {
+        return $this->getWrappedObject()->isLive();
+    }
+
+    public function getAccessControlManager()
+    {
+        return $this->getWrapper()->wrap($this->getWrappedObject()->getAccessControlManager(), 'PHPCR\Security\AccessControlManagerInterface');
+    }
+
+    public function getRetentionManager()
+    {
+        return $this->getWrapper()->wrap($this->getWrappedObject()->getRetentionManager(), 'PHPCR\Retention\RetentionManagerInterface');
+    }
+
+    public function executeQuery($jcrSql2)
+    {
+        $res = $this->getWorkspace()->getQueryManager()->createQuery($jcrSql2, 'JCR-SQL2')->execute();
+
+        return $this->getWrapper()->wrapMany($res->getNodes(), 'PHPCR\NodeInterface');
+    }
+}

--- a/src/Sulu/Component/PHPCR/Wrapper/Traits/WrappedObjectTrait.php
+++ b/src/Sulu/Component/PHPCR/Wrapper/Traits/WrappedObjectTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Sulu\Component\PHPCR\Wrapper\Traits;
+
+trait WrappedObjectTrait
+{
+    protected $object;
+
+    public function setWrappedObject($object)
+    {
+        $this->object = $object;
+    }
+
+    public function getWrappedObject()
+    {
+        return $this->object;
+    }
+
+    public function call($method, $args = array())
+    {
+        return call_user_func_array(array($this->getWrappedObject(), $method), $args);
+    }
+}

--- a/src/Sulu/Component/PHPCR/Wrapper/Traits/WrapperAwareTrait.php
+++ b/src/Sulu/Component/PHPCR/Wrapper/Traits/WrapperAwareTrait.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Sulu\Component\PHPCR\Wrapper\Traits;
+
+use Sulu\Component\PHPCR\Wrapper\WrapperInterface;
+
+trait WrapperAwareTrait
+{
+    protected $wrapper;
+
+    public function setWrapper(WrapperInterface $wrapper)
+    {
+        $this->wrapper = $wrapper;
+    }
+
+    public function getWrapper()
+    {
+        return $this->wrapper;
+    }
+}

--- a/src/Sulu/Component/PHPCR/Wrapper/Wrapped/Node.php
+++ b/src/Sulu/Component/PHPCR/Wrapper/Wrapped/Node.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Sulu\Component\PHPCR\Wrapper\Wrapped;
+
+use Sulu\Component\PHPCR\Wrapper\WrappedObjectInterface;
+use Sulu\Component\PHPCR\Wrapper\Traits\NodeTrait;
+use PHPCR\NodeInterface;
+use Sulu\Component\PHPCR\Wrapper\WrapperAwareInterface;
+
+class Node implements \IteratorAggregate, WrappedObjectInterface, NodeInterface, WrapperAwareInterface
+{
+    use NodeTrait;
+
+    public function getIterator()
+    {
+        return $this->getNodes();
+    }
+}

--- a/src/Sulu/Component/PHPCR/Wrapper/Wrapped/Property.php
+++ b/src/Sulu/Component/PHPCR/Wrapper/Wrapped/Property.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Sulu\Component\PHPCR\Wrapper\Wrapped;
+
+use Sulu\Component\PHPCR\Wrapper\Traits\PropertyTrait;
+use Sulu\Component\PHPCR\Wrapper\WrappedObjectInterface;
+use PHPCR\PropertyInterface;
+use Sulu\Component\PHPCR\Wrapper\WrapperAwareInterface;
+
+class Property implements \IteratorAggregate, WrappedObjectInterface, PropertyInterface, WrapperAwareInterface
+{
+    use PropertyTrait;
+
+    public function getIterator()
+    {
+        return $this->getWrappedObject()->getIterator();
+    }
+}

--- a/src/Sulu/Component/PHPCR/Wrapper/Wrapped/Session.php
+++ b/src/Sulu/Component/PHPCR/Wrapper/Wrapped/Session.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Sulu\Component\PHPCR\Wrapper\Wrapped;
+
+use Sulu\Component\PHPCR\Wrapper\WrapperAwareInterface;
+use Sulu\Component\PHPCR\Wrapper\WrappedObjectInterface;
+use Sulu\Component\PHPCR\Wrapper\Traits\SessionTrait;
+use PHPCR\SessionInterface;
+
+/**
+ * The session wraps the PHPCR session and
+ * uses the NodeMapper to return node type specific
+ * objects if they exist.
+ *
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+class Session implements SessionInterface, WrapperAwareInterface, WrappedObjectInterface
+{
+    use SessionTrait;
+}

--- a/src/Sulu/Component/PHPCR/Wrapper/WrappedObjectInterface.php
+++ b/src/Sulu/Component/PHPCR/Wrapper/WrappedObjectInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Sulu\Component\PHPCR\Wrapper;
+
+interface WrappedObjectInterface
+{
+    /**
+     * Set the wrapped object
+     *
+     * @param object
+     */
+    public function setWrappedObject($object);
+
+    /**
+     * Return the wrapped PHPCR node
+     *
+     * @return object
+     */
+    public function getWrappedObject();
+}

--- a/src/Sulu/Component/PHPCR/Wrapper/Wrapper/SimpleWrapper.php
+++ b/src/Sulu/Component/PHPCR/Wrapper/Wrapper/SimpleWrapper.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Sulu\Component\PHPCR\Wrapper\Wrapper;
+
+use Sulu\Component\PHPCR\Wrapper\WrapperInterface;
+use Sulu\Component\PHPCR\Wrapper\WrapperAwareInterface;
+
+/**
+ * The simple mapper simply maps nodes to the given target
+ * class.
+ */
+class SimpleWrapper implements WrapperInterface
+{
+    protected $classMap;
+
+    public function __construct(array $classMap)
+    {
+        $this->classMap = $classMap;
+    }
+
+    public function wrap($object, $className)
+    {
+        if (!isset($this->classMap[$className])) {
+            return $object;
+        }
+
+        $wrapperClass = $this->classMap[$className];
+
+        $refl = new \ReflectionClass($wrapperClass);
+
+        if (!$refl->isSubclassOf('Sulu\Component\PHPCR\Wrapper\WrappedObjectInterface')) {
+            throw new Exception\WrapperException(sprintf(
+                'Wrapped class "%s" must implement WrappedObjectInterface',
+                $wrapperClass
+            ));
+        }
+
+        if (!$refl->isSubclassOf($className)) {
+            throw new Exception\WrapperException(sprintf(
+                'Wrapper class "%s" does not implement the interface for "%s"',
+                $wrapperClass,
+                $className
+            ));
+        }
+
+        $wrappedNode = new $wrapperClass($node);
+        $wrappedNode->setWrappedObject($object);
+
+        if ($wrappedNode instanceof WrapperAwareInterface) {
+            $wrappedNode->setWrapper($this);
+        }
+
+        return $wrappedNode;
+    }
+
+    public function wrapMany($collection, $className)
+    {
+        foreach ($collection as $key => &$node) {
+            $collection[$key] = $this->wrap($node, $className);
+        }
+
+        return $collection;
+    }
+}

--- a/src/Sulu/Component/PHPCR/Wrapper/WrapperAwareInterface.php
+++ b/src/Sulu/Component/PHPCR/Wrapper/WrapperAwareInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Sulu\Component\PHPCR\Wrapper;
+
+/**
+ * Enabes wrapper object to be set on (wrapped) objects.
+ *
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+interface WrapperAwareInterface
+{
+    /**
+     * Set the wrapper
+     *
+     * @param WrapperInterface $wrapper
+     */
+    public function setWrapper(WrapperInterface $wrapper);
+
+    /**
+     * Return the Wrapper
+     *
+     * @return Wrapper
+     */
+    public function getWrapper();
+}

--- a/src/Sulu/Component/PHPCR/Wrapper/WrapperInterface.php
+++ b/src/Sulu/Component/PHPCR/Wrapper/WrapperInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Sulu\Component\PHPCR\Wrapper;
+
+use PHPCR\ObjectInterface;
+
+/**
+ * Object Wrapper Interface
+ *
+ * Object wrappers wrap custom classes around objects.
+ */
+interface WrapperInterface
+{
+    /**
+     * Wrap a single node
+     *
+     * @param ObjectInterface $node
+     */
+    public function wrap($object, $className);
+
+    /**
+     * Wrap multiple nodes
+     *
+     * @param ObjectInterface[]
+     */
+    public function wrapMany($objects, $className);
+}

--- a/tests/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtensionTest.php
+++ b/tests/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtensionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Sulu\Bundle\CoreBundle\DependencyInjection;
+
+use Sulu\Bundle\CoreBundle\DependencyInjection\SuluCoreExtension;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+
+class SuluCoreExtensionTest extends AbstractExtensionTestCase
+{
+    protected function getContainerExtensions()
+    {
+        return array(
+            new SuluCoreExtension
+        );
+    }
+
+    public function testLoad()
+    {
+        $this->load();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'sulu.phpcr.wrapper',
+            0,
+            array(
+                'PHPCR\SessionInterface' => 'Sulu\Component\PHPCR\Wrapper\Wrapped\Session',
+                'PHPCR\NodeInterface' => 'Sulu\Component\PHPCR\Wrapper\Wrapped\Node',
+                'PHPCR\PropertyInterface' => 'Sulu\Component\PHPCR\Wrapper\Wrapped\Property',
+            )
+        );
+    }
+}

--- a/tests/Sulu/Component/PHPCR/Wrapper/Traits/WrappedObjectTraitTest.php
+++ b/tests/Sulu/Component/PHPCR/Wrapper/Traits/WrappedObjectTraitTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Sulu\Component\PHPCR\Wrapper\Traits;
+
+use Sulu\Component\PHPCR\Wrapper\WrappedObjectInterface;
+use Sulu\Component\PHPCR\Wrapper\Traits\WrappedObjectTrait;;
+
+class WrappedObjectTraitTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDefaultValue()
+    {
+        $wrapperObject = new TestWrappedObjectTraitClass;
+        $wrappedObject = new TestWrappedObjectSubject();
+        $wrapperObject->setWrappedObject($wrappedObject);
+
+        $wrapperObject->thisIsAMethod('Hello');
+        $this->assertEquals('FOOBAR', $wrapperObject->getWrappedObject()->z);
+    }
+}
+
+class TestWrappedObjectTraitClass implements WrappedObjectInterface
+{
+    use WrappedObjectTrait;
+
+    protected $wrappedObject;
+
+
+    public function getWrappedObject() 
+    {
+        return $this->wrappedObject;
+    }
+    
+    public function setWrappedObject($wrappedObject)
+    {
+        $this->wrappedObject = $wrappedObject;
+    }
+    
+
+    public function thisIsAMethod($x, $z = null)
+    {
+        return $this->call('thisIsAMethod', func_get_args());
+    }
+}
+
+class TestWrappedObjectSubject
+{
+    public $x;
+    public $z;
+
+    public function thisIsAMethod($x, $z = 'FOOBAR')
+    {
+        $this->x = $x;
+        $this->z = $z;
+    }
+}

--- a/tests/Sulu/Component/PHPCR/Wrapper/Wrapped/NodeTest.php
+++ b/tests/Sulu/Component/PHPCR/Wrapper/Wrapped/NodeTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Sulu\Component\PHPCR\Wrapped\Wrapper;
+
+use Sulu\Component\PHPCR\Wrapper\Wrapped\Node;
+
+class NodeTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->node = new Node;
+        $this->wrapped = $this->getMock('PHPCR\NodeInterface');
+        $this->wrapper = $this->getMock('Sulu\Component\PHPCR\Wrapper\WrapperInterface');
+        $this->node->setWrappedObject($this->wrapped);
+        $this->node->setWrapper($this->wrapper);
+    }
+
+    public function provideObjectReturn()
+    {
+        return array(
+            array('wrap', 'addNode', 'PHPCR\NodeInterface', array('asd')),
+            array('wrap', 'getDefinition', 'PHPCR\NodeType\NodeDefinitionInterface'),
+            array('wrapMany', 'getMixinNodeTypes', 'PHPCR\NodeType\NodeTypeInterface'),
+            array('wrap', 'getNode', 'PHPCR\NodeInterface', array('/foo')),
+            array('wrapMany', 'getNodes', 'PHPCR\NodeInterface'),
+            array('wrap', 'getPrimaryItem', 'PHPCR\ItemInterface'),
+            array('wrap', 'getPrimaryNodeType', 'PHPCR\NodeType\NodeTypeInterface'),
+            array('wrapMany', 'getProperties', 'PHPCR\PropertyInterface'),
+            array('wrap', 'getProperty', 'PHPCR\PropertyInterface', array('/prop')),
+            array('wrapMany', 'getReferences', 'PHPCR\PropertyInterface'),
+            array('wrapMany', 'getSharedSet', 'PHPCR\NodeInterface'),
+            array('wrap', 'getParent', 'PHPCR\NodeInterface'),
+            array('wrap', 'getSession', 'PHPCR\SessionInterface'),
+        );
+    }
+
+    /**
+     * @dataProvider provideObjectReturn
+     */
+    public function testObjectReturn($wrapMethod, $method, $expectedClass, $args = array())
+    {
+        $this->wrapped->expects($this->once())
+            ->method($method);
+
+        $this->wrapper->expects($this->once())
+            ->method($wrapMethod)
+            ->with(null, $expectedClass);
+
+        $refl = new \ReflectionClass(get_class($this->node));
+        $method = $refl->getMethod($method);
+        $method->invokeArgs($this->node, $args);
+    }
+
+    public function provideUnwrappedMethod()
+    {
+        return array(
+            array('addMixin', array('nt:mixin')),
+            array('addNodeAutoNamed', array()),
+            array('canAddMixin', array('mix')),
+            array('followLifecycleTransition', array('asd')),
+            array('getAllowedLifecycleTransitions'),
+            array('getCorrespondingNodePath', array('workspace')),
+            array('getIdentifier'),
+            array('getIndex'),
+            array('getNodeNames'),
+            array('getPrimaryNodeType'),
+            array('getPropertiesValues'),
+            array('getPropertyValue', array('asd')),
+            array('getPropertyValueWithDefault', array('asd', 'asd')),
+            array('getWeakReferences'),
+            array('hasNode', array('asd')),
+            array('hasNodes', array()),
+            array('hasProperties', array()),
+            array('hasProperty', array('asd')),
+            array('isCheckedOut', array()),
+            array('isLocked', array()),
+            array('isNodeType', array('ads')),
+            array('orderBefore', array('asd', 'asd')),
+            array('removeMixin', array('asd')),
+            array('removeShare', array()),
+            array('removeSharedSet', array()),
+            array('rename', array('asd')),
+            array('setMixins', array(array('asd', 'asd'))),
+            array('setPrimaryType', array('asd')),
+            array('setProperty', array('asd', 'asd')),
+            array('update', array(true)),
+        );
+    }
+
+    /**
+     * @dataProvider provideUnwrappedMethod
+     */
+    public function testUnwrappedMethod($method, $args = array())
+    {
+        $this->wrapped->expects($this->once())
+            ->method($method);
+
+        $refl = new \ReflectionClass(get_class($this->node));
+        $method = $refl->getMethod($method);
+        $method->invokeArgs($this->node, $args);
+    }
+
+    public function testIterator()
+    {
+        $this->wrapped->expects($this->once())
+            ->method('getNodes')
+            ->will($this->returnValue(array(
+                'asd'
+            )));
+        $this->wrapper->expects($this->once())
+            ->method('wrapMany')
+            ->will($this->returnValue(array(
+                'asd'
+            )));
+
+        $this->node->getNodes();
+    }
+
+    public function testPreservingDefaultValueInWrapped()
+    {
+    }
+}

--- a/tests/Sulu/Component/PHPCR/Wrapper/Wrapped/PropertyTest.php
+++ b/tests/Sulu/Component/PHPCR/Wrapper/Wrapped/PropertyTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Sulu\Component\PHPCR\Wrapper\Wrapped;
+
+use Sulu\Component\PHPCR\Wrapper\Wrapped\Property;
+
+class PropertyTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->node = new Property;
+        $this->wrapped = $this->getMock('PHPCR\PropertyInterface');
+        $this->wrapper = $this->getMock('Sulu\Component\PHPCR\Wrapper\WrapperInterface');
+        $this->node->setWrappedObject($this->wrapped);
+        $this->node->setWrapper($this->wrapper);
+    }
+
+    public function provideObjectReturn()
+    {
+        return array(
+            array('wrap', 'getDefinition', 'PHPCR\PropertyDefinitionInterface'),
+            array('wrap', 'getNode', 'PHPCR\NodeInterface'),
+            array('wrap', 'getProperty', 'PHPCR\PropertyInterface'),
+        );
+    }
+
+    /**
+     * @dataProvider provideObjectReturn
+     */
+    public function testObjectReturn($wrapMethod, $method, $expectedClass, $args = array())
+    {
+        $this->wrapped->expects($this->once())
+            ->method($method);
+
+        $this->wrapper->expects($this->once())
+            ->method($wrapMethod)
+            ->with(null, $expectedClass);
+
+        $refl = new \ReflectionClass(get_class($this->node));
+        $method = $refl->getMethod($method);
+        $method->invokeArgs($this->node, $args);
+    }
+
+    public function provideUnwrappedMethod()
+    {
+        return array(
+            array('addValue', array('asd')),
+            array('getBinary', array()),
+            array('getBoolean', array()),
+            array('getDate', array()),
+            array('getDecimal', array()),
+            array('getDouble', array()),
+            array('getLength', array()),
+            array('getLong', array()),
+            array('getString', array()),
+            array('getType', array()),
+            array('getValue', array()),
+            array('isMultiple', array()),
+            array('setValue', array('asd')),
+        );
+    }
+
+    /**
+     * @dataProvider provideUnwrappedMethod
+     */
+    public function testUnwrappedMethod($method, $args = array())
+    {
+        $this->wrapped->expects($this->once())
+            ->method($method);
+
+        $refl = new \ReflectionClass(get_class($this->node));
+        $method = $refl->getMethod($method);
+        $method->invokeArgs($this->node, $args);
+    }
+}

--- a/tests/Sulu/Component/PHPCR/Wrapper/Wrapped/SessionTest.php
+++ b/tests/Sulu/Component/PHPCR/Wrapper/Wrapped/SessionTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Sulu\Component\PHPCR\Wrapper\Wrapped;
+
+use Sulu\Component\PHPCR\Wrapper\Wrapped\Session;
+
+class SessionTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->session = new Session;
+        $this->wrapped = $this->getMock('PHPCR\SessionInterface');
+        $this->wrapper = $this->getMock('Sulu\Component\PHPCR\Wrapper\WrapperInterface');
+        $this->session->setWrappedObject($this->wrapped);
+        $this->session->setWrapper($this->wrapper);
+    }
+
+    public function provideObjectReturn()
+    {
+        return array(
+            array('wrap', 'getAccessControlManager', 'PHPCR\Security\AccessControlManagerInterface'),
+            array('wrap', 'getItem', 'PHPCR\ItemInterface', array('/')),
+            array('wrap', 'getNode', 'PHPCR\NodeInterface', array('/')),
+            array('wrap', 'getNodeByIdentifier', 'PHPCR\NodeInterface', array('/asd')),
+            array('wrapMany', 'getNodes', 'PHPCR\NodeInterface', array(array())),
+            array('wrapMany', 'getNodesByIdentifier', 'PHPCR\NodeInterface', array(array())),
+            array('wrapMany', 'getProperties', 'PHPCR\PropertyInterface', array('/')),
+            array('wrap', 'getProperty', 'PHPCR\PropertyInterface', array('/')),
+            array('wrap', 'getRepository', 'PHPCR\RepositoryInterface'),
+            array('wrap', 'getRetentionManager', 'PHPCR\Retention\RetentionManagerInterface'),
+            array('wrap', 'getRootNode', 'PHPCR\NodeInterface')
+        );
+    }
+
+    /**
+     * @dataProvider provideObjectReturn
+     */
+    public function testObjectReturn($wrapMethod, $method, $expectedClass, $args = array())
+    {
+        $this->wrapped->expects($this->once())
+            ->method($method);
+
+        $this->wrapper->expects($this->once())
+            ->method($wrapMethod)
+            ->with(null, $expectedClass);
+
+        $refl = new \ReflectionClass(get_class($this->session));
+        $method = $refl->getMethod($method);
+        $method->invokeArgs($this->session, $args);
+    }
+
+    public function provideUnwrappedMethod()
+    {
+        return array(
+            array('checkPermission', array('asd', 'asd')),
+            array('exportDocumentView', array('asd', 'asd', 'asd', 'asd')),
+            array('exportSystemView', array('asd', 'asd', 'asd', 'asd')),
+            array('getAttribute', array('asd')),
+            array('getAttributeNames', array('asd', 'asd')),
+            array('getNamespacePrefix', array('asd', 'asd')),
+            array('getNamespacePrefixes', array('asd', 'asd')),
+            array('getNamespaceURI', array('asd', 'asd')),
+            array('getUserID'),
+            array('getWorkspace', array('asd')),
+            array('hasCapability', array('asd', 'ar', array())),
+            array('hasPendingChanges'),
+            array('hasPermission', array('perm', 'asd')),
+            array('importXML', array('/', 'asd', 'nasd')),
+            array('isLive'),
+            array('itemExists', array('/')),
+            array('logout'),
+            array('move', array('/', '/')),
+            array('nodeExists', array('/')),
+            array('propertyExists', array('/prop')),
+            array('refresh', array(true)),
+            array('removeItem', array('prop')),
+            array('save'),
+            array('setNamespacePrefix', array('foobar', 'barfoo')),
+        );
+    }
+
+    /**
+     * @dataProvider provideUnwrappedMethod
+     */
+    public function testUnwrappedMethod($method, $args = array())
+    {
+        $this->wrapped->expects($this->once())
+            ->method($method);
+
+        $refl = new \ReflectionClass(get_class($this->session));
+        $method = $refl->getMethod($method);
+        $method->invokeArgs($this->session, $args);
+    }
+}

--- a/tests/Sulu/Component/PHPCR/Wrapper/Wrapper/SimpleWrapperTest.php
+++ b/tests/Sulu/Component/PHPCR/Wrapper/Wrapper/SimpleWrapperTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Sulu\Component\PHPCR\Wrapper\Wrapper;
+
+use Sulu\Component\PHPCR\Wrapper\WrappedObjectInterface;
+use Sulu\Component\PHPCR\Wrapper\Traits\NodeTrait;
+use PHPCR\NodeInterface;
+
+class SimpleWrapperTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->wrapper = new SimpleWrapper(array(
+            'PHPCR\NodeInterface' => 'Sulu\Component\PHPCR\Wrapper\Wrapper\TestWrappedNode'
+        ));
+
+        $this->phpcrNode = $this->getMock('PHPCR\NodeInterface');
+    }
+
+    public function testWrapObject()
+    {
+        $wrappedObject = $this->wrapper->wrap($this->phpcrNode, 'PHPCR\NodeInterface');
+        $this->assertInstanceOf('Sulu\Component\PHPCR\Wrapper\Wrapper\TestWrappedNode', $wrappedObject);
+        $this->assertSame($this->phpcrNode, $wrappedObject->getWrappedObject());
+    }
+
+    public function testWrapMany()
+    {
+        $res = $this->wrapper->wrapMany(new \ArrayObject($this->phpcrNode), 'PHPCR\NodeInterface');
+        $this->assertInstanceOf('\ArrayObject', $res);
+    }
+}
+
+class TestWrappedNode implements \IteratorAggregate, WrappedObjectInterface, NodeInterface
+{
+    use NodeTrait;
+
+    protected $object;
+
+    public function setWrappedObject($object)
+    {
+        $this->object = $object;
+    }
+
+    public function getWrappedObject()
+    {
+        return $this->object;
+    }
+
+    public function getIterator()
+    {
+        return $this->getNodes();
+    }
+}


### PR DESCRIPTION
The PHPCR wrapper ultimately aims to be able to wrap all of the PHPCR
objects as required.

Currently it wraps the `Session`, `Node` and `Property` classes, and enables us to use our own classes and effectively
extend the nodes returned from the PHPCR repository.

__Tasks:__

- [x] test coverage
- [ ] gather feedback for my changes

__Next Steps__

This PR could be split into two packages:

- Wrapper package: The wrapping logic is completely generic
- PHPCR-API Wrapper: Depending on Wrapper package and containing all the PHPCR wrapper objects and Traits.

__Informations:__

| Q             | A
| ------------- | ---
| Tests pass?   | yes
| Fixed tickets | #173 
| BC Breaks     | NO
| Doc           | not yet