### PR TITLE
[WIP] Better handling of case where template key does not match

### DIFF
--- a/src/Sulu/Component/Content/StructureManager.php
+++ b/src/Sulu/Component/Content/StructureManager.php
@@ -19,6 +19,7 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerAware;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\Resource\FileResource;
+use Doctrine\Common\Util\Inflector;
 
 /**
  * generates subclasses of structure to match template definitions.
@@ -177,7 +178,7 @@ class StructureManager extends ContainerAware implements StructureManagerInterfa
     {
         $fileName = $templateConfig['path'];
 
-        $class = str_replace('-', '_', ucfirst($key)) . $this->options['cache_class_suffix'];
+        $class = Inflector::camelize($key) . $this->options['cache_class_suffix'];
         $cache = new ConfigCache(
             $this->options['cache_dir'] . '/' . $class . '.php',
             $this->options['debug']
@@ -188,7 +189,10 @@ class StructureManager extends ContainerAware implements StructureManagerInterfa
                 $result = $this->loader->load($fileName);
 
                 if ($result['key'] !== $key) {
-                    throw new TemplateNotFoundException($fileName, $key);
+                    throw new \InvalidArgumentException(sprintf(
+                        'Template with filename "%s" loaded for key "%s" but the key it defines is "%s"',
+                        $fileName, $key, $result['key']
+                    ));
                 }
 
                 $resources[] = new FileResource($fileName);

--- a/tests/Resources/DataFixtures/Template/template_key_mismatch.xml
+++ b/tests/Resources/DataFixtures/Template/template_key_mismatch.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>key_not_same_as_filename</key>
+
+    <view>page.html.twig</view>
+    <controller>SuluContentBundle:Default:index</controller>
+    <cacheLifetime>2400</cacheLifetime>
+    <index name="foo_index" />
+
+    <meta>
+        <title lang="de">Das ist das Template 1</title>
+        <title lang="en">That´s the template 1</title>
+    </meta>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <meta>
+                <title lang="de">Titel</title>
+            </meta>
+
+            <tag name="sulu.node.name"/>
+        </property>
+
+    </properties>
+</template>

--- a/tests/Sulu/Component/Content/StructureManager/StructureMangerTest.php
+++ b/tests/Sulu/Component/Content/StructureManager/StructureMangerTest.php
@@ -571,6 +571,17 @@ class StructureMangerTest extends \PHPUnit_Framework_TestCase
         $extensions = array_values($this->structureManager->getExtensions('template_sections'));
         $this->assertEquals('test1', $extensions[0]->getName());
     }
+
+    public function testGetStructureFilenameKeyMismatch()
+    {
+        try {
+            $this->structureManager->getStructure('template_key_mismatch');
+        } catch (\Exception $e) {
+            $previous = $e->getPrevious();
+            $this->assertInstanceOf('InvalidArgumentException', $previous);
+            $this->assertContains('but the key it defines is', $previous->getMessage());
+        }
+    }
 }
 
 class TestExtension extends StructureExtension
@@ -607,4 +618,3 @@ class TestExtension extends StructureExtension
         );
     }
 }
-


### PR DESCRIPTION
Throw more precise exception information when key doesn't match and
use the Inflector class to create cache class name.

Fixes https://github.com/sulu-cmf/sulu/issues/233

See last comment