### PR TITLE
[POC] Added repository initializer

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/Initializer/SuluInitializer.php
+++ b/src/Sulu/Bundle/CoreBundle/Initializer/SuluInitializer.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Sulu\Bundle\CoreBundle\Initializer;
+
+use Doctrine\Bundle\PHPCRBundle\Initializer\InitializerInterface;
+use Doctrine\Bundle\PHPCRBundle\ManagerRegistry;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use PHPCR\Util\NodeHelper;
+
+class SuluInitializer implements InitializerInterface
+{
+    protected $basePath;
+    protected $webspaceManager;
+
+    public function __construct(
+        WebspaceManagerInterface $webspaceManager,
+        $baseNodeName,
+        $contentNodeName,
+        $routeNodeName,
+        $tempNodeName
+    )
+    {
+        $this->nodeNames = array(
+            'base' => $baseNodeName,
+            'content' => $contentNodeName,
+            'route' => $routeNodeName,
+            'temp' => $tempNodeName
+        );
+        $this->webspaceManager = $webspaceManager;
+    }
+
+    public function getName()
+    {
+        return 'Sulu Webspace Initializer';
+    }
+
+    public function init(ManagerRegistry $registry)
+    {
+        $session = $registry->getManager()->getPhpcrSession();
+        $webspaceCollection = $this->webspaceManager->getWebspaceCollection();
+
+        foreach ($webspaceCollection as $webspace) {
+            foreach (array('content', 'route', 'temp') as $nodeName) {
+                NodeHelper::createPath($session, sprintf(
+                    '%s/%s/%s',
+                    $this->nodeNames['base'],
+                    $webspace->getKey(),
+                    $nodeName
+                ));
+            }
+        }
+
+        $session->save();
+    }
+}

--- a/src/Sulu/Bundle/CoreBundle/Initializer/SuluInitializer.php
+++ b/src/Sulu/Bundle/CoreBundle/Initializer/SuluInitializer.php
@@ -6,14 +6,24 @@ use Doctrine\Bundle\PHPCRBundle\Initializer\InitializerInterface;
 use Doctrine\Bundle\PHPCRBundle\ManagerRegistry;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use PHPCR\Util\NodeHelper;
+use PHPCR\NodeInterface;
+use Sulu\Component\Content\Mapper\ContentMapper;
+use PHPCR\Util\PathHelper;
+use Sulu\Component\Content\Mapper\ContentMapperRequest;
+use Sulu\Component\Content\Structure;
+use Sulu\Component\Content\StructureInterface;
+use Sulu\Component\Webspace\Webspace;
+use Sulu\Component\Webspace\Localization;
 
 class SuluInitializer implements InitializerInterface
 {
-    protected $basePath;
-    protected $webspaceManager;
+    private $nodeNames;
+    private $webspaceManager;
+    private $contentMapper;
 
     public function __construct(
         WebspaceManagerInterface $webspaceManager,
+        ContentMapper $contentMapper,
         $baseNodeName,
         $contentNodeName,
         $routeNodeName,
@@ -27,6 +37,7 @@ class SuluInitializer implements InitializerInterface
             'temp' => $tempNodeName
         );
         $this->webspaceManager = $webspaceManager;
+        $this->contentMapper = $contentMapper;
     }
 
     public function getName()
@@ -40,16 +51,53 @@ class SuluInitializer implements InitializerInterface
         $webspaceCollection = $this->webspaceManager->getWebspaceCollection();
 
         foreach ($webspaceCollection as $webspace) {
-            foreach (array('content', 'route', 'temp') as $nodeName) {
-                NodeHelper::createPath($session, sprintf(
+            foreach (array('contents', 'route', 'temp') as $nodeName) {
+                $path = sprintf(
                     '%s/%s/%s',
                     $this->nodeNames['base'],
                     $webspace->getKey(),
                     $nodeName
-                ));
+                );
+
+                switch ($nodeName) {
+                    case 'contents': 
+                        $node = NodeHelper::createPath($session, $path);
+                        $node->addMixin('mix:referenceable');
+                        $session->save();
+
+                        foreach ($webspace->getLocalizations() as $localization) {
+                            $this->createHomepage($webspace, $localization, $node);
+                        }
+                        $session->save();
+                        break;
+                    case 'route':
+                        // $this->createBaseRoutes($node);
+                        break;
+                }
             }
         }
+    }
 
-        $session->save();
+    public function createHomepage(Webspace $webspace, Localization $localization, $node)
+    {
+        $request = ContentMapperRequest::create()
+            ->setType(Structure::TYPE_PAGE)
+            ->setData(array(
+                'title' => ''
+            ))
+            ->setTemplateKey('overview')
+            ->setUserId(1)
+            ->setLocale($localization->getLocalization())
+            ->setUuid($node->getIdentifier())
+            ->setWebspaceKey($webspace->getKey())
+            ->setState(StructureInterface::STATE_PUBLISHED);
+
+        $this->contentMapper->saveRequest($request);
+
+        $subLocalizations = $localization->getChildren() ? : array();
+
+        foreach ($subLocalizations as $subLocalization) {
+            $this->createHomepage($webspace, $subLocalization, $node);
+        }
     }
 }

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/phpcr.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/phpcr.xml
@@ -18,5 +18,14 @@
                 <argument key="snippet">%sulu.content.node_names.snippet%</argument>
             </argument>
         </service>
+
+        <service id="sulu.phpcr.initializer" class="Sulu\Bundle\CoreBundle\Initializer\SuluInitializer">
+            <argument type="service" id="sulu_core.webspace.webspace_manager" />
+            <argument key="base">%sulu.content.node_names.base%</argument>
+            <argument key="content">%sulu.content.node_names.content%</argument>
+            <argument key="route">%sulu.content.node_names.route%</argument>
+            <argument key="temp">%sulu.content.node_names.temp%</argument>
+            <tag name="doctrine_phpcr.initializer"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/phpcr.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/phpcr.xml
@@ -21,6 +21,7 @@
 
         <service id="sulu.phpcr.initializer" class="Sulu\Bundle\CoreBundle\Initializer\SuluInitializer">
             <argument type="service" id="sulu_core.webspace.webspace_manager" />
+            <argument type="service" id="sulu.content.mapper" />
             <argument key="base">%sulu.content.node_names.base%</argument>
             <argument key="content">%sulu.content.node_names.content%</argument>
             <argument key="route">%sulu.content.node_names.route%</argument>


### PR DESCRIPTION
This is the method provided by the DoctrinePHPCRBundle to both register node types and create the initial repository structure.

It would therefore mean we could remove both `sulu:phpcr:init` and `sulu:webspace:init` commands.

It should however be complemented with some minimal fixtures for the homepage.

__TODO__:

- [ ] Register node types (as CND files or we could use the auto register feature in the new PHPCRODM Bundle)
- [ ] Homepage / route fixtures