### PR TITLE
Feature/command improvements

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Command/CreateRoleCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/CreateRoleCommand.php
@@ -43,13 +43,25 @@ class CreateRoleCommand extends ContainerAwareCommand
     {
         $doctrine = $this->getContainer()->get('doctrine');
         $em = $doctrine->getManager();
-        $now = new \Datetime();
+        $name = $input->getArgument('name');
+        $system = $input->getArgument('system');
+
+        $repository = $em->getRepository('Sulu\Bundle\SecurityBundle\Entity\Role');
+
+        $role = $repository->findOneByName($name);
+
+        if ($role) {
+            $output->writeln(sprintf(
+                '<error>Role "%s" already exists</error>',
+                $name
+            ));
+
+            return 1;
+        }
 
         $role = new Role();
-        $role->setName($input->getArgument('name'));
-        $role->setSystem($input->getArgument('system'));
-        $role->setCreated($now);
-        $role->setChanged($now);
+        $role->setName($name);
+        $role->setSystem($system);
 
         $pool = $this->getContainer()->get('sulu_admin.admin_pool');
         $securityContexts = $pool->getSecurityContexts();

--- a/src/Sulu/Bundle/SecurityBundle/Command/CreateRoleCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/CreateRoleCommand.php
@@ -46,7 +46,7 @@ class CreateRoleCommand extends ContainerAwareCommand
         $name = $input->getArgument('name');
         $system = $input->getArgument('system');
 
-        $repository = $em->getRepository('Sulu\Bundle\SecurityBundle\Entity\Role');
+        $repository = $em->getRepository('SuluSecurityBundle:Role');
 
         $role = $repository->findOneByName($name);
 

--- a/src/Sulu/Bundle/SecurityBundle/Command/CreateUserCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/CreateUserCommand.php
@@ -70,7 +70,7 @@ class CreateUserCommand extends ContainerAwareCommand
         $roleName = $input->getArgument('role');
         $password = $input->getArgument('password');
 
-        $doctrine = $this->getContainer()->get('doctrine');
+        $doctrine = $this->getDoctrine();
         $em = $doctrine->getManager();
 
         $emailTypes = $doctrine->getRepository('SuluContactBundle:EmailType')->findAll();
@@ -80,6 +80,13 @@ class CreateUserCommand extends ContainerAwareCommand
                 'Cannot find any SuluContactBundle:EmailType entities in database, maybe you ' .
                 'should load the fixtures?'
             );
+        }
+
+        $user = $doctrine->getRepository('Sulu\Bundle\SecurityBundle\Entity\User')->findOneByUsername($username);
+
+        if ($user) {
+            $output->writeln(sprintf('<error>User "%s" already exists</error>', $username));
+            return 1;
         }
 
         $email = new Email();
@@ -108,7 +115,16 @@ class CreateUserCommand extends ContainerAwareCommand
         $user->setSalt($this->generateSalt());
         $user->setPassword($this->encodePassword($user, $password, $user->getSalt()));
         $user->setLocale($locale);
+
         $role = $doctrine->getRepository('SuluSecurityBundle:Role')->findOneBy(array('name' => $roleName));
+
+        if (!$role) {
+            throw new \InvalidArgumentException(sprintf(
+                'Role "%s" not found. The following roles are registered: "%s"',
+                $roleName,
+                implode('", "', $this->getRoleNames())
+            ));
+        }
 
         $userRole = new UserRole();
         $userRole->setRole($role);
@@ -130,7 +146,7 @@ class CreateUserCommand extends ContainerAwareCommand
     protected function interact(InputInterface $input, OutputInterface $output)
     {
         $helper = $this->getHelper('question');
-        $doctrine = $this->getContainer()->get('doctrine');
+        $doctrine = $this->getDoctrine();
 
         if (!$input->getArgument('username')) {
             $question = new Question('Please choose a username: ');
@@ -220,22 +236,13 @@ class CreateUserCommand extends ContainerAwareCommand
         }
 
         if (!$input->getArgument('role')) {
-            $query = $doctrine->getRepository('SuluSecurityBundle:Role')
-                ->createQueryBuilder('role')
-                ->select('role.name')
-                ->getQuery();
-
-            $roles = array();
-            foreach ($query->getArrayResult() as $roleEntity) {
-                $roles[] = $roleEntity['name'];
-            }
+            $roleNames = $this->getRoleNames();
 
             $question = new ChoiceQuestion(
                 'Please choose a role: ',
-                $roles,
+                $roleNames,
                 0
             );
-
             $value = $helper->ask($input, $output, $question);
             $input->setArgument('role', $value);
         }
@@ -279,5 +286,15 @@ class CreateUserCommand extends ContainerAwareCommand
         $encoder = $this->getContainer()->get('security.encoder_factory')->getEncoder($user);
 
         return $encoder->encodePassword($password, $salt);
+    }
+
+    private function getRoleNames()
+    {
+        return $this->getDoctrine()->getRepository('SuluSecurityBundle:Role')->getRoleNames();
+    }
+
+    private function getDoctrine()
+    {
+        return $this->getContainer()->get('doctrine');
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/Command/CreateUserCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/CreateUserCommand.php
@@ -82,7 +82,7 @@ class CreateUserCommand extends ContainerAwareCommand
             );
         }
 
-        $user = $doctrine->getRepository('Sulu\Bundle\SecurityBundle\Entity\User')->findOneByUsername($username);
+        $user = $doctrine->getRepository('SuluSecurityBundle:User')->findOneByUsername($username);
 
         if ($user) {
             $output->writeln(sprintf('<error>User "%s" already exists</error>', $username));
@@ -288,11 +288,28 @@ class CreateUserCommand extends ContainerAwareCommand
         return $encoder->encodePassword($password, $salt);
     }
 
+    /**
+     * Return the names of all the roles
+     *
+     * @return array
+     * @throws RuntimeException If no roles exist
+     */
     private function getRoleNames()
     {
-        return $this->getDoctrine()->getRepository('SuluSecurityBundle:Role')->getRoleNames();
+        $roleNames = $this->getDoctrine()->getRepository('SuluSecurityBundle:Role')->getRoleNames();
+
+        if (empty($roleNames)) {
+            throw new \RuntimeException(sprintf(
+                'The system currently has no roles. Use the "sulu:security:role:create" command to create roles.'
+            ));
+        }
     }
 
+    /**
+     * Return the doctrine service
+     *
+     * @return Doctrine\Common\Persistence\ManagerRegistry
+     */
     private function getDoctrine()
     {
         return $this->getContainer()->get('doctrine');

--- a/src/Sulu/Bundle/SecurityBundle/Entity/BaseRole.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/BaseRole.php
@@ -57,6 +57,18 @@ abstract class BaseRole implements RoleInterface
     private $securityType;
 
     /**
+     * Update updated and created fields before save
+     */
+    public function beforeSave()
+    {
+        if (null == $this->created) {
+            $this->created = new \DateTime();
+        }
+
+        $this->changed = new \DateTime();
+    }
+
+    /**
      * Set name
      *
      * @param string $name

--- a/src/Sulu/Bundle/SecurityBundle/Entity/BaseRole.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/BaseRole.php
@@ -57,9 +57,11 @@ abstract class BaseRole implements RoleInterface
     private $securityType;
 
     /**
-     * Update updated and created fields before save
+     * Update the timestamps (changed + created).
+     * This method is mapped to the PRE_PERSIST and PRE_UPDATE
+     * lifecycle events.
      */
-    public function beforeSave()
+    public function updateTimestamps()
     {
         if (null == $this->created) {
             $this->created = new \DateTime();

--- a/src/Sulu/Bundle/SecurityBundle/Entity/RoleRepository.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/RoleRepository.php
@@ -21,8 +21,9 @@ use Doctrine\ORM\Query;
 class RoleRepository extends EntityRepository
 {
     /**
-     * Searches for a role with a specific id
-     * @param $id
+     * Finds a role with a specific id
+     *
+     * @param $id ID of the role
      * @return role
      */
     public function findRoleById($id)
@@ -49,6 +50,7 @@ class RoleRepository extends EntityRepository
 
     /**
      * Searches for all roles
+     *
      * @return array
      */
     public function findAllRoles()
@@ -69,5 +71,24 @@ class RoleRepository extends EntityRepository
         } catch (NoResultException $ex) {
             return null;
         }
+    }
+
+    /**
+     * Return an array containing the names of all the roles
+     *
+     * @return array
+     */
+    public function getRoleNames()
+    {
+        $query = $this->createQueryBuilder('role')
+            ->select('role.name')
+            ->getQuery();
+
+        $roles = array();
+        foreach ($query->getArrayResult() as $roleEntity) {
+            $roles[] = $roleEntity['name'];
+        }
+
+        return $roles;
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/BaseRole.orm.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/BaseRole.orm.xml
@@ -28,5 +28,10 @@
             </join-columns>
         </many-to-one>
 
+        <lifecycle-callbacks>
+            <lifecycle-callback type="prePersist" method="beforeSave" />
+            <lifecycle-callback type="preUpdate" method="beforeSave" />
+        </lifecycle-callbacks>
+
     </mapped-superclass>
 </doctrine-mapping>

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/BaseRole.orm.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/BaseRole.orm.xml
@@ -29,8 +29,8 @@
         </many-to-one>
 
         <lifecycle-callbacks>
-            <lifecycle-callback type="prePersist" method="beforeSave" />
-            <lifecycle-callback type="preUpdate" method="beforeSave" />
+            <lifecycle-callback type="prePersist" method="updateTimestamps" />
+            <lifecycle-callback type="preUpdate" method="updateTimestamps" />
         </lifecycle-callbacks>
 
     </mapped-superclass>

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Entity/RoleTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Entity/RoleTest.php
@@ -23,7 +23,7 @@ class RoleTest extends \PHPUnit_Framework_TestCase
 
     public function testBeforeSave()
     {
-        $this->role->beforeSave();
+        $this->role->updateTimestamps();
         $this->assertNotNull($this->role->getCreated());
         $this->assertNotNull($this->role->getChanged());
 
@@ -32,7 +32,7 @@ class RoleTest extends \PHPUnit_Framework_TestCase
         $this->role->setCreated($created);
         $this->role->setChanged($changed);
 
-        $this->role->beforeSave();
+        $this->role->updateTimestamps();
 
         $this->assertEquals($created, $this->role->getCreated());
         $this->assertGreaterThan($changed->format('c'), $this->role->getChanged()->format('c'));

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Entity/RoleTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Entity/RoleTest.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ * This file is part of the Sulu CMF.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SecurityBundle\EventListener;
+
+use Sulu\Bundle\SecurityBundle\Entity\Role;
+
+class RoleTest extends \PHPUnit_Framework_TestCase
+{
+    private $role;
+
+    public function setUp()
+    {
+        $this->role = new Role();
+    }
+
+    public function testBeforeSave()
+    {
+        $this->role->beforeSave();
+        $this->assertNotNull($this->role->getCreated());
+        $this->assertNotNull($this->role->getChanged());
+
+        $created = new \DateTime('2013-01-01');
+        $changed = new \DateTime('2013-04-01');
+        $this->role->setCreated($created);
+        $this->role->setChanged($changed);
+
+        $this->role->beforeSave();
+
+        $this->assertEquals($created, $this->role->getCreated());
+        $this->assertGreaterThan($changed->format('c'), $this->role->getChanged()->format('c'));
+    }
+}


### PR DESCRIPTION
This PR contains 3 commits which fix some issues in the user/role commands

- Handle the case where either a role or a user already exists
- Handle the case where the requested role does not exist (non-interactive)
- Indicate which roles *are* available in the Exception message (non-interactive)
- Handle the case where no roles exist (interactive)
- Added `preUpdate` and `prePersist` hooks to set the created + changed fields on the `Role` entity.

__Tasks:__

- [x] test coverage
- [ ] gather feedback for my changes
- [ ] added changelog line


__Informations:__

| Q             | A
| ------------- | ---
| Tests pass?   | yes
| Fixed tickets | #683 ]
| BC Breaks     | NO
| Doc           | NO
