### PR TITLE
SecurityBundle command improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ CHANGELOG for Sulu
     * BUGFIX      #848 [ContactBundle]   Refactored delete dialog function to make it reuseable
     * BUGFIX      #846 [MediaBundle]     Added missing dot to create event name method (\cc Daniel)
     * ENHANCEMENT #841 [SecurityBundle]  Unique email per user
+    * BUGFIX      #698 [SecurityBundle]  Create user command - do not crash when no roles exist.
+    * ENHANCEMENT #698 [SecurityBundle]  Create user/role commands - exit gracefully if user / role already exists
+    * ENHANCEMENT #698 [SecurityBundle]  Create user command - validate locale when creating new user
     * BUGFIX      #837 [AdminBundle]     Javascript function for croping labels with a certain tag this.sandbox.sulu.cropAllLabels(className)
 
 * 0.15.1 (2015-02-17)
@@ -54,7 +57,7 @@ CHANGELOG for Sulu
     * BUGFIX      #697 [CoreBundle]      Do not try and set the theme when the portal has not been found
     * FEATURE     #697 [HttpCacheBundle] Refactored HTTP cache, introduced Varnish support. See 38af8da73c929f9f57bb87a8973a1ee55dccee29
     * ENHANCEMENT #777 [ContentBundle]   Enable "copy language" on startpage
-    * HOTFIX      #788 [ContentBundle]  Fixed bug with empty selection with single internal link
+    * HOTFIX      #788 [ContentBundle]   Fixed bug with empty selection with single internal link
 
 * 0.14.2 (2015-02-02)
     * HOTFIX      #781 [CoreBundle]     HTTP Cache event listener uses the wrong event name due to recent change

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Configuration.php
@@ -28,6 +28,7 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('sulu_core');
+        $rootNode->addDefaultsIfNotSet();
 
         $children = $rootNode->children();
         $this->getPhpcrConfiguration($children);
@@ -56,8 +57,9 @@ class Configuration implements ConfigurationInterface
     private function getLocaleConfiguration(NodeBuilder $rootNode)
     {
         $rootNode->arrayNode('locales')
+            ->isRequired()
             ->useAttributeAsKey('locale')
-            ->prototype('scalar')
+            ->prototype('scalar')->end()
         ->end();
     }
 

--- a/src/Sulu/Bundle/CoreBundle/Tests/DependencyInjection/SuluCoreExtensionTest.php
+++ b/src/Sulu/Bundle/CoreBundle/Tests/DependencyInjection/SuluCoreExtensionTest.php
@@ -16,7 +16,9 @@ class SuluCoreExtensionTest extends AbstractExtensionTestCase
 
     public function testLoadNoConfig()
     {
-        $this->load();
+        $this->load(array(
+            'locales' => array('en', 'de')
+        ));
         $this->assertContainerBuilderHasServiceDefinitionWithTag(
             'sulu.cache.warmer.structure', 'kernel.cache_warmer'
         );
@@ -42,7 +44,8 @@ class SuluCoreExtensionTest extends AbstractExtensionTestCase
                     ),
                     'paths' => array(),
                 )
-            )
+            ),
+            'locales' => array('en', 'de')
         ));
 
         $this->assertEquals(

--- a/src/Sulu/Bundle/SecurityBundle/Command/CreateRoleCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/CreateRoleCommand.php
@@ -43,11 +43,26 @@ class CreateRoleCommand extends ContainerAwareCommand
     {
         $doctrine = $this->getContainer()->get('doctrine');
         $em = $doctrine->getManager();
-        $now = new \Datetime();
+        $now = new \DateTime();
+        $name = $input->getArgument('name');
+        $system = $input->getArgument('system');
+
+        $repository = $em->getRepository('SuluSecurityBundle:Role');
+
+        $role = $repository->findOneByName($name);
+
+        if ($role) {
+            $output->writeln(sprintf(
+                '<error>Role "%s" already exists.</error>',
+                $name
+            ));
+
+            return 1;
+        }
 
         $role = new Role();
-        $role->setName($input->getArgument('name'));
-        $role->setSystem($input->getArgument('system'));
+        $role->setName($name);
+        $role->setSystem($system);
         $role->setCreated($now);
         $role->setChanged($now);
 
@@ -77,7 +92,7 @@ class CreateRoleCommand extends ContainerAwareCommand
 
         $output->writeln(
             sprintf(
-                'Created role <comment>%s</comment> in system <comment>%s</comment>',
+                'Created role "<comment>%s</comment>" in system "<comment>%s</comment>".',
                 $role->getName(),
                 $role->getSystem()
             )

--- a/src/Sulu/Bundle/SecurityBundle/Command/CreateUserCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/CreateUserCommand.php
@@ -58,6 +58,7 @@ class CreateUserCommand extends ContainerAwareCommand
     {
         $localizations = $this->getContainer()->get('sulu.core.localization_manager')->getLocalizations();
         $locales = array();
+        $userLocales = $this->getContainer()->getParameter('sulu_core.locales');
 
         foreach ($localizations as $localization) {
             $locales[] = $localization->getLocalization();
@@ -71,10 +72,30 @@ class CreateUserCommand extends ContainerAwareCommand
         $roleName = $input->getArgument('role');
         $password = $input->getArgument('password');
 
-        $doctrine = $this->getContainer()->get('doctrine');
+        $doctrine = $this->getDoctrine();
         $em = $doctrine->getManager();
+        $user = $this->getUser();
 
         $now = new DateTime();
+
+        $existing = $doctrine->getRepository(get_class($user))->findOneBy(array('username' => $username));
+
+        if ($existing) {
+            $output->writeln(sprintf('<error>User "%s" already exists</error>',
+                $username
+            ));
+
+            return 1;
+        }
+
+        if (!in_array($locale, $userLocales)) {
+            $output->writeln(sprintf(
+                'Given locale "%s" is invalid, must be one of "%s"',
+                $locale, implode('", "', $userLocales)
+            ));
+
+            return 1;
+        }
 
         $contact = new Contact();
         $contact->setFirstName($firstName);
@@ -85,7 +106,6 @@ class CreateUserCommand extends ContainerAwareCommand
         $em->persist($contact);
         $em->flush();
 
-        $user = $this->getUser();
         $user->setContact($contact);
         $user->setUsername($username);
         $user->setSalt($this->generateSalt());
@@ -94,6 +114,15 @@ class CreateUserCommand extends ContainerAwareCommand
         $user->setEmail($email);
 
         $role = $doctrine->getRepository('SuluSecurityBundle:Role')->findOneBy(array('name' => $roleName));
+
+        if (!$role) {
+            $output->writeln(sprintf('<error>Role "%s" not found. The following roles are available: "%s"</error>',
+                $roleName,
+                implode('", "', $this->getRoleNames())
+            ));
+
+            return 1;
+        }
 
         $userRole = new UserRole();
         $userRole->setRole($role);
@@ -105,7 +134,7 @@ class CreateUserCommand extends ContainerAwareCommand
         $em->flush();
 
         $output->writeln(
-            sprintf('Created user <comment>%s</comment> in role <comment>%s</comment>', $username, $roleName)
+            sprintf('Created user "<comment>%s</comment>" in role "<comment>%s</comment>"', $username, $roleName)
         );
     }
 
@@ -124,8 +153,10 @@ class CreateUserCommand extends ContainerAwareCommand
      */
     protected function interact(InputInterface $input, OutputInterface $output)
     {
+        $roleNames = $this->getRoleNames();
         $helper = $this->getHelper('question');
-        $doctrine = $this->getContainer()->get('doctrine');
+        $doctrine = $this->getDoctrine();
+        $userLocales = $this->getContainer()->getParameter('sulu_core.locales');
 
         if (!$input->getArgument('username')) {
             $question = new Question('Please choose a username: ');
@@ -207,38 +238,17 @@ class CreateUserCommand extends ContainerAwareCommand
         }
 
         if (!$input->getArgument('locale')) {
-            $question = new Question('Please choose a locale: ');
-            $question->setValidator(
-                function ($locale) use ($doctrine) {
-                    if (empty($locale)) {
-                        throw new \InvalidArgumentException('Locale can not be empty');
-                    }
-
-                    return $locale;
-                }
-            );
-
+            $question = new ChoiceQuestion('Please choose a locale', $userLocales);
             $value = $helper->ask($input, $output, $question);
             $input->setArgument('locale', $value);
         }
 
         if (!$input->getArgument('role')) {
-            $query = $doctrine->getRepository('SuluSecurityBundle:Role')
-                ->createQueryBuilder('role')
-                ->select('role.name')
-                ->getQuery();
-
-            $roles = array();
-            foreach ($query->getArrayResult() as $roleEntity) {
-                $roles[] = $roleEntity['name'];
-            }
-
             $question = new ChoiceQuestion(
                 'Please choose a role: ',
-                $roles,
+                $roleNames,
                 0
             );
-
             $value = $helper->ask($input, $output, $question);
             $input->setArgument('role', $value);
         }
@@ -282,5 +292,33 @@ class CreateUserCommand extends ContainerAwareCommand
         $encoder = $this->getContainer()->get('security.encoder_factory')->getEncoder($user);
 
         return $encoder->encodePassword($password, $salt);
+    }
+
+    /**
+     * Return the names of all the roles
+     *
+     * @return array
+     * @throws RuntimeException If no roles exist
+     */
+    private function getRoleNames()
+    {
+        $roleNames = $this->getDoctrine()->getRepository('SuluSecurityBundle:Role')->getRoleNames();
+
+        if (empty($roleNames)) {
+            throw new \RuntimeException(sprintf(
+                'The system currently has no roles. Use the "sulu:security:role:create" command to create roles.'
+            ));
+        }
+
+        return $roleNames;
+    }
+
+    /**
+     * Return the doctrine service
+     * @return Doctrine\Common\Persistence\ManagerRegistry
+     */
+    private function getDoctrine()
+    {
+        return $this->getContainer()->get('doctrine');
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/Entity/RoleRepository.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/RoleRepository.php
@@ -21,8 +21,9 @@ use Doctrine\ORM\Query;
 class RoleRepository extends EntityRepository
 {
     /**
-     * Searches for a role with a specific id
-     * @param $id
+     * Finds a role with a specific id
+     *
+     * @param $id ID of the role
      * @return role
      */
     public function findRoleById($id)
@@ -49,6 +50,7 @@ class RoleRepository extends EntityRepository
 
     /**
      * Searches for all roles
+     *
      * @return array
      */
     public function findAllRoles()
@@ -69,5 +71,24 @@ class RoleRepository extends EntityRepository
         } catch (NoResultException $ex) {
             return null;
         }
+    }
+
+    /**
+     * Return an array containing the names of all the roles
+     *
+     * @return array
+     */
+    public function getRoleNames()
+    {
+        $query = $this->createQueryBuilder('role')
+            ->select('role.name')
+            ->getQuery();
+
+        $roles = array();
+        foreach ($query->getArrayResult() as $roleEntity) {
+            $roles[] = $roleEntity['name'];
+        }
+
+        return $roles;
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Command/CreateRoleCommandTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Command/CreateRoleCommandTest.php
@@ -36,16 +36,28 @@ class CreateRoleCommandTest extends SuluTestCase
         $this->tester = new CommandTester($createUserCommand);
     }
 
-    public function testExecute()
+    public function testCreateRole()
+    {
+        $this->createRole('foo');
+        $this->assertEquals('Created role "foo" in system "Sulu".' . PHP_EOL, $this->tester->getDisplay());
+    }
+
+    public function testCreateRoleAlreadyExisting()
+    {
+        $this->createRole('foo');
+        $this->createRole('foo');
+
+        $this->assertEquals('Role "foo" already exists.' . PHP_EOL, $this->tester->getDisplay());
+    }
+
+    private function createRole($name)
     {
         $this->tester->execute(
             array(
-                'name' => 'test',
+                'name' => $name,
                 'system' => 'Sulu'
             ),
             array('interactive' => false)
         );
-
-        $this->assertEquals("Created role test in system Sulu\n", $this->tester->getDisplay());
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Command/CreateUserCommandTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Command/CreateUserCommandTest.php
@@ -23,6 +23,11 @@ class CreateUserCommandTest extends SuluTestCase
      */
     private $tester;
 
+    /**
+     * @var CreateUserCommand
+     */
+    private $command;
+
     public function setUp()
     {
         $application = new Application($this->getContainer()->get('kernel'));
@@ -32,16 +37,58 @@ class CreateUserCommandTest extends SuluTestCase
         $loadFixturesCommandTester = new CommandTester($loadFixturesCommand);
         $loadFixturesCommandTester->execute(array(), array('interactive' => false));
 
-        $createUserCommand = new CreateUserCommand();
-        $createUserCommand->setApplication($application);
-        $this->tester = new CommandTester($createUserCommand);
+        $this->command = new CreateUserCommand();
+        $this->command->setApplication($application);
+        $this->tester = new CommandTester($this->command);
+    }
 
+    public function testCreateUser()
+    {
+        $this->createRole('test');
+        $this->createUser('sulu', 'test');
+        $this->assertEquals('Created user "sulu" in role "test"' . PHP_EOL, $this->tester->getDisplay());
+    }
+
+    public function testCreateUserAlreadyExists()
+    {
+        $this->createRole('test');
+        $this->createUser('sulu', 'test');
+        $this->createUser('sulu', 'test');
+
+        $this->assertEquals("User \"sulu\" already exists\n", $this->tester->getDisplay());
+    }
+
+    public function testCreateUserNonExistingRole()
+    {
+        $this->createRole('test');
+        $this->createUser('sulu', 'testfoobar');
+        $this->assertEquals('Role "testfoobar" not found. The following roles are available: "test"' . PHP_EOL, $this->tester->getDisplay());
+    }
+
+    public function testCreateUserNonExistingLocale()
+    {
+        $this->createRole('test');
+        $this->createUser('sulu', 'test', 'ax');
+        $this->assertContains('Given locale "ax" is invalid, must be one of "', $this->tester->getDisplay());
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage The system currently has no roles. Use the "sulu:security:role:create" command to create roles.
+     */
+    public function testCreateUserNoRoles()
+    {
+        $this->createUser('sulu', 'blah');
+    }
+
+    private function createRole($roleName)
+    {
         $doctrine = $this->getContainer()->get('doctrine');
         $em = $doctrine->getManager();
         $now = new \Datetime();
 
         $role = new Role();
-        $role->setName('test');
+        $role->setName($roleName);
         $role->setSystem('Sulu');
         $role->setCreated($now);
         $role->setChanged($now);
@@ -50,7 +97,7 @@ class CreateUserCommandTest extends SuluTestCase
         $em->flush();
     }
 
-    public function testExecute()
+    private function createUser($username, $role, $locale = 'en')
     {
         $this->tester->execute(
             array(
@@ -58,13 +105,11 @@ class CreateUserCommandTest extends SuluTestCase
                 'firstName' => 'Sulu',
                 'lastName' => 'Hikaru',
                 'email' => 'sulu.hikaru@startrek.com',
-                'locale' => 'en',
-                'role' => 'test',
+                'locale' => $locale,
+                'role' => $role,
                 'password' => 'sulu'
             ),
             array('interactive' => false)
         );
-
-        $this->assertEquals("Created user sulu in role test\n", $this->tester->getDisplay());
     }
 }

--- a/src/Sulu/Bundle/TestBundle/Resources/dist/sulu.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/dist/sulu.yml
@@ -36,6 +36,7 @@ sulu_core:
                      internal: false
                      type: snippet
     webspace: ~
+    locales: [ "en", "de" ]
 
 sulu_admin:
     name: SULU 2.0


### PR DESCRIPTION
- Do not crash if role already exists
    - Show error message instead and exit with status 1
    - Handle case where no roles exist
- Handle errors in CreateUser command
    - Handle case where requested role does not exist
    - Handle case where username already exists

__Tasks:__

- [x] test coverage
- [x] gather feedback for my changes
- [x] added changelog line

__Informations:__

| Q             | A
| ------------- | ---
| Tests pass?   | yes
| Fixed tickets | fixes https://github.com/sulu-cmf/sulu/issues/465
| BC Breaks     | 
| Doc           | 