### PR TITLE
Automatic timestamps and user blame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * FEATURE     #732 [All]             Automatic mapping and assignation of changer, creator, changed and changer.
     * FEATURE     #891 [All]             Added (css) class property to field descriptors, updated husky and fixed an issue when merging settings with matchings
     * FEATURE     #884 [MediaBundle]     Loaders on media delete and media edit
     * BUGFIX      #884 [AdminBundle]     Fix for login displacement issues

--- a/src/Sulu/Bundle/CategoryBundle/Category/CategoryManager.php
+++ b/src/Sulu/Bundle/CategoryBundle/Category/CategoryManager.php
@@ -230,6 +230,8 @@ class CategoryManager implements CategoryManagerInterface
                 return $this->createCategory($data, $this->getUser($userId));
             }
         } catch (\Doctrine\DBAL\DBALException $e) {
+            // FIXME: This hides any exceptions thrown by DBAL. 
+            //        See https://github.com/sulu-cmf/sulu/issues/871
             throw new KeyNotUniqueException();
         }
     }
@@ -312,8 +314,6 @@ class CategoryManager implements CategoryManagerInterface
         $categoryEntity = new CategoryEntity();
         $categoryEntity->setCreator($user);
         $categoryEntity->setChanger($user);
-        $categoryEntity->setCreated(new \DateTime());
-        $categoryEntity->setChanged(new \DateTime());
 
         $categoryWrapper = $this->getApiObject($categoryEntity, $data['locale']);
         $categoryWrapper->setName($data['name']);
@@ -349,7 +349,6 @@ class CategoryManager implements CategoryManagerInterface
             throw new EntityNotFoundException($categoryEntity, $data['id']);
         }
 
-        $categoryEntity->setChanged(new \DateTime());
         $categoryEntity->setChanger($user);
 
         $categoryWrapper = $this->getApiObject($categoryEntity, $data['locale']);

--- a/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -128,7 +128,7 @@ class CategoryController extends RestController implements ClassResourceInterfac
             $wrappers = $categoryManager->getApiObjects($categories, $this->getLocale($request));
             $list = new CollectionRepresentation($wrappers, self::$entityKey);
         }
-        $view = $this->view($list, 200);
+       $view = $this->view($list, 200);
 
         return $this->handleView($view);
     }

--- a/src/Sulu/Bundle/CategoryBundle/Entity/Category.php
+++ b/src/Sulu/Bundle/CategoryBundle/Entity/Category.php
@@ -2,10 +2,12 @@
 
 namespace Sulu\Bundle\CategoryBundle\Entity;
 
+use Sulu\Component\Persistence\Model\AuditableInterface;
+
 /**
  * Category
  */
-class Category
+class Category implements AuditableInterface
 {
     /**
      * @var integer
@@ -152,19 +154,6 @@ class Category
     }
 
     /**
-     * Set created
-     *
-     * @param \DateTime $created
-     * @return Category
-     */
-    public function setCreated($created)
-    {
-        $this->created = $created;
-
-        return $this;
-    }
-
-    /**
      * Get created
      *
      * @return \DateTime
@@ -172,19 +161,6 @@ class Category
     public function getCreated()
     {
         return $this->created;
-    }
-
-    /**
-     * Set changed
-     *
-     * @param \DateTime $changed
-     * @return Category
-     */
-    public function setChanged($changed)
-    {
-        $this->changed = $changed;
-
-        return $this;
     }
 
     /**

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/Category.orm.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/Category.orm.xml
@@ -21,8 +21,6 @@
         <field name="depth" type="integer" column="depth">
             <gedmo:tree-level/>
         </field>
-        <field name="created" type="datetime" column="created"/>
-        <field name="changed" type="datetime" column="changed"/>
 
         <one-to-many field="meta" target-entity="Sulu\Bundle\CategoryBundle\Entity\CategoryMeta" mapped-by="category">
             <cascade>
@@ -41,17 +39,6 @@
                 <join-column name="idCategoriesParent" referenced-column-name="id" on-delete="CASCADE"/>
             </join-columns>
             <gedmo:tree-parent/>
-        </many-to-one>
-
-        <many-to-one field="creator" target-entity="Sulu\Component\Security\Authentication\UserInterface">
-            <join-columns>
-                <join-column name="idUsersCreator" referenced-column-name="id" on-delete="SET NULL" nullable="true"/>
-            </join-columns>
-        </many-to-one>
-        <many-to-one field="changer" target-entity="Sulu\Component\Security\Authentication\UserInterface">
-            <join-columns>
-                <join-column name="idUsersChanger" referenced-column-name="id" on-delete="SET NULL" nullable="true"/>
-            </join-columns>
         </many-to-one>
 
         <gedmo:tree type="nested"/>

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
@@ -55,8 +55,6 @@ class CategoryControllerTest extends SuluTestCase
         /* First Category
         -------------------------------------*/
         $category = new Category();
-        $category->setCreated(new \DateTime());
-        $category->setChanged(new \DateTime());
         $category->setKey('first-category-key');
 
         // name for first category
@@ -81,8 +79,6 @@ class CategoryControllerTest extends SuluTestCase
         /* Second Category
         -------------------------------------*/
         $category2 = new Category();
-        $category2->setCreated(new \DateTime());
-        $category2->setChanged(new \DateTime());
         $category2->setKey('second-category-key');
         $this->category2 = $category2;
 
@@ -113,8 +109,6 @@ class CategoryControllerTest extends SuluTestCase
         /* Third Category (child of first)
         -------------------------------------*/
         $category3 = new Category();
-        $category3->setCreated(new \DateTime());
-        $category3->setChanged(new \DateTime());
         $category3->setParent($category);
         $this->category3 = $category3;
 
@@ -138,8 +132,6 @@ class CategoryControllerTest extends SuluTestCase
         /* Fourth Category (child of third)
         -------------------------------------*/
         $category4 = new Category();
-        $category4->setCreated(new \DateTime());
-        $category4->setChanged(new \DateTime());
         $category4->setParent($category3);
         $this->category4 = $category4;
 

--- a/src/Sulu/Bundle/ContactBundle/Api/Account.php
+++ b/src/Sulu/Bundle/ContactBundle/Api/Account.php
@@ -44,7 +44,6 @@ use JMS\Serializer\Annotation\Groups;
  */
 class Account extends ApiWrapper
 {
-
     /**
      * @param AccountEntity $account
      * @param string $locale The locale of this product
@@ -147,19 +146,6 @@ class Account extends ApiWrapper
     }
 
     /**
-     * Set created
-     *
-     * @param \DateTime $created
-     * @return Account
-     */
-    public function setCreated($created)
-    {
-        $this->entity->setCreated($created);
-
-        return $this;
-    }
-
-    /**
      * Get created
      *
      * @return \DateTime
@@ -170,19 +156,6 @@ class Account extends ApiWrapper
     public function getCreated()
     {
         return $this->entity->getCreated();
-    }
-
-    /**
-     * Set changed
-     *
-     * @param \DateTime $changed
-     * @return Account
-     */
-    public function setChanged($changed)
-    {
-        $this->entity->setChanged($changed);
-
-        return $this;
     }
 
     /**

--- a/src/Sulu/Bundle/ContactBundle/Api/Activity.php
+++ b/src/Sulu/Bundle/ContactBundle/Api/Activity.php
@@ -23,6 +23,7 @@ use JMS\Serializer\Annotation\VirtualProperty;
 use JMS\Serializer\Annotation\SerializedName;
 use JMS\Serializer\Annotation\ExclusionPolicy;
 use JMS\Serializer\Annotation\Groups;
+use Sulu\Component\Persistence\Model\AuditableInterface;
 
 /**
  * The Activity class which will be exported to the API
@@ -160,19 +161,6 @@ class Activity extends ApiWrapper
     }
 
     /**
-     * Set created
-     *
-     * @param \DateTime $created
-     * @return Activity
-     */
-    public function setCreated($created)
-    {
-        $this->entity->setCreated($created);
-
-        return $this;
-    }
-
-    /**
      * Get created
      *
      * @return \DateTime
@@ -183,19 +171,6 @@ class Activity extends ApiWrapper
     public function getCreated()
     {
         return $this->entity->getCreated();
-    }
-
-    /**
-     * Set changed
-     *
-     * @param \DateTime $changed
-     * @return Activity
-     */
-    public function setChanged($changed)
-    {
-        $this->entity->setChanged($changed);
-
-        return $this;
     }
 
     /**

--- a/src/Sulu/Bundle/ContactBundle/Api/Contact.php
+++ b/src/Sulu/Bundle/ContactBundle/Api/Contact.php
@@ -242,19 +242,6 @@ class Contact extends ApiWrapper
     }
 
     /**
-     * Set created
-     *
-     * @param \DateTime $created
-     * @return Contact
-     */
-    public function setCreated($created)
-    {
-        $this->entity->setCreated($created);
-
-        return $this;
-    }
-
-    /**
      * Get created
      *
      * @return \DateTime
@@ -265,19 +252,6 @@ class Contact extends ApiWrapper
     public function getCreated()
     {
         return $this->entity->getCreated();
-    }
-
-    /**
-     * Set changed
-     *
-     * @param \DateTime $changed
-     * @return Contact
-     */
-    public function setChanged($changed)
-    {
-        $this->entity->setChanged($changed);
-
-        return $this;
     }
 
     /**

--- a/src/Sulu/Bundle/ContactBundle/Behat/ContactContext.php
+++ b/src/Sulu/Bundle/ContactBundle/Behat/ContactContext.php
@@ -58,8 +58,6 @@ class ContactContext extends BaseContext implements SnippetAcceptingContext
         $email->setEmailType($type);
 
         $contact->addEmail($email);
-        $contact->setCreated(new \DateTime());
-        $contact->setChanged(new \DateTime());
         $contact->setDisabled(0);
         $contact->setFormOfAddress(0);
 

--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -496,8 +496,6 @@ class AccountController extends AbstractContactController
             $this->setParent($request->get('parent'), $account);
 
             // set creator / changer
-            $account->setCreated(new DateTime());
-            $account->setChanged(new DateTime());
             $account->setCreator($this->getUser());
             $account->setChanger($this->getUser());
 
@@ -584,7 +582,6 @@ class AccountController extends AbstractContactController
                 $this->setParent($request->get('parent'), $account);
 
                 // set changed
-                $account->setChanged(new DateTime());
                 $user = $this->getUser();
                 $account->setChanger($user);
 

--- a/src/Sulu/Bundle/ContactBundle/Controller/ActivityController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/ActivityController.php
@@ -459,7 +459,6 @@ class ActivityController extends RestController implements ClassResourceInterfac
             $this->processActivityData($activity, $request);
 
             $activity->setCreator($this->getUser());
-            $activity->setCreated(new \DateTime());
 
             $em->persist($activity);
             $em->flush();
@@ -615,7 +614,6 @@ class ActivityController extends RestController implements ClassResourceInterfac
         }
 
         // changer and changed
-        $activity->setChanged(new \DateTime());
         $activity->setChanger($this->getUser());
     }
 

--- a/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
@@ -614,8 +614,6 @@ class ContactController extends AbstractContactController
                 $contact->setBirthday(new DateTime($birthday));
             }
 
-            $contact->setCreated(new DateTime());
-            $contact->setChanged(new DateTime());
 
             $contact->setFormOfAddress($formOfAddress['id']);
 
@@ -695,7 +693,6 @@ class ContactController extends AbstractContactController
                 // Set title relation on contact
                 $this->setTitleOnContact($contact, $request->get('title'));
 
-                $contact->setChanged(new DateTime());
 
                 $this->getContactManager()->setMainAccount($contact, $request->request->all());
 

--- a/src/Sulu/Bundle/ContactBundle/Entity/Account.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/Account.php
@@ -13,11 +13,12 @@ namespace Sulu\Bundle\ContactBundle\Entity;
 use JMS\Serializer\Annotation\Exclude;
 use JMS\Serializer\Annotation\Accessor;
 use Sulu\Bundle\CoreBundle\Entity\ApiEntity;
+use Sulu\Component\Persistence\Model\AuditableInterface;
 
 /**
  * Account
  */
-class Account extends ApiEntity
+class Account extends ApiEntity implements AuditableInterface
 {
 
     const TYPE_BASIC = 0;
@@ -335,19 +336,6 @@ class Account extends ApiEntity
     }
 
     /**
-     * Set created
-     *
-     * @param \DateTime $created
-     * @return Account
-     */
-    public function setCreated($created)
-    {
-        $this->created = $created;
-
-        return $this;
-    }
-
-    /**
      * Get created
      *
      * @return \DateTime
@@ -355,19 +343,6 @@ class Account extends ApiEntity
     public function getCreated()
     {
         return $this->created;
-    }
-
-    /**
-     * Set changed
-     *
-     * @param \DateTime $changed
-     * @return Account
-     */
-    public function setChanged($changed)
-    {
-        $this->changed = $changed;
-
-        return $this;
     }
 
     /**

--- a/src/Sulu/Bundle/ContactBundle/Entity/Activity.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/Activity.php
@@ -4,11 +4,12 @@ namespace Sulu\Bundle\ContactBundle\Entity;
 
 use JMS\Serializer\Annotation\Exclude;
 use Sulu\Bundle\CoreBundle\Entity\ApiEntity;
+use Sulu\Component\Persistence\Model\AuditableInterface;
 
 /**
  * Activity
  */
-class Activity extends ApiEntity
+class Activity extends ApiEntity implements AuditableInterface
 {
     /**
      * @var string
@@ -180,19 +181,6 @@ class Activity extends ApiEntity
     }
 
     /**
-     * Set created
-     *
-     * @param \DateTime $created
-     * @return Activity
-     */
-    public function setCreated($created)
-    {
-        $this->created = $created;
-
-        return $this;
-    }
-
-    /**
      * Get created
      *
      * @return \DateTime
@@ -200,19 +188,6 @@ class Activity extends ApiEntity
     public function getCreated()
     {
         return $this->created;
-    }
-
-    /**
-     * Set changed
-     *
-     * @param \DateTime $changed
-     * @return Activity
-     */
-    public function setChanged($changed)
-    {
-        $this->changed = $changed;
-
-        return $this;
     }
 
     /**

--- a/src/Sulu/Bundle/ContactBundle/Entity/Contact.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/Contact.php
@@ -15,11 +15,12 @@ use JMS\Serializer\Annotation\Exclude;
 use JMS\Serializer\Annotation\VirtualProperty;
 use JMS\Serializer\Annotation\SerializedName;
 use JMS\Serializer\Annotation\Accessor;
+use Sulu\Component\Persistence\Model\AuditableInterface;
 
 /**
  * Contact
  */
-class Contact extends ApiEntity
+class Contact extends ApiEntity implements AuditableInterface
 {
 
     /**
@@ -386,19 +387,6 @@ class Contact extends ApiEntity
     }
 
     /**
-     * Set created
-     *
-     * @param \DateTime $created
-     * @return Contact
-     */
-    public function setCreated($created)
-    {
-        $this->created = $created;
-
-        return $this;
-    }
-
-    /**
      * Get created
      *
      * @return \DateTime
@@ -406,19 +394,6 @@ class Contact extends ApiEntity
     public function getCreated()
     {
         return $this->created;
-    }
-
-    /**
-     * Set changed
-     *
-     * @param \DateTime $changed
-     * @return Contact
-     */
-    public function setChanged($changed)
-    {
-        $this->changed = $changed;
-
-        return $this;
     }
 
     /**

--- a/src/Sulu/Bundle/ContactBundle/Import/Import.php
+++ b/src/Sulu/Bundle/ContactBundle/Import/Import.php
@@ -674,8 +674,6 @@ class Import
             $account = $this->createNewAccount();
         }
 
-        $account->setChanged(new \DateTime());
-        $account->setCreated(new \DateTime());
 
         if ($this->checkData('account_name', $data)) {
             $account->setName($data['account_name']);
@@ -1007,8 +1005,6 @@ class Import
         } else {
             $tag = new Tag();
             $tag->setName($tagName);
-            $tag->setCreated(new \DateTime());
-            $tag->setChanged(new \DateTime());
             $this->em->persist($tag);
             $this->tags[$tag->getName()] = $tag;
         }
@@ -1378,9 +1374,6 @@ class Import
         if ($this->checkData('contact_disabled', $data)) {
             $contact->setDisabled($this->getBoolValue($data['contact_disabled']));
         }
-
-        $contact->setChanged(new \DateTime());
-        $contact->setCreated(new \DateTime());
 
         // check company
         $this->em->persist($contact);

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/doctrine/Account.orm.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/doctrine/Account.orm.xml
@@ -26,9 +26,6 @@
 
         <field name="corporation" type="string" column="corporation" length="255" nullable="true"/>
 
-        <field name="created" type="datetime" column="created"/>
-        <field name="changed" type="datetime" column="changed"/>
-
         <field name="disabled" type="integer" column="disabled" length="1" nullable="false"/>
         <field name="type" type="integer" column="type" nullable="false" />
 
@@ -56,17 +53,6 @@
         <many-to-one field="mainContact" target-entity="Sulu\Bundle\ContactBundle\Entity\Contact">
             <join-columns>
                 <join-column name="idContactsMain" referenced-column-name="id" on-delete="SET NULL" nullable="true"/>
-            </join-columns>
-        </many-to-one>
-
-        <many-to-one field="changer" target-entity="Sulu\Component\Security\Authentication\UserInterface">
-            <join-columns>
-                <join-column name="idUsersChanger" referenced-column-name="id" on-delete="SET NULL" nullable="true"/>
-            </join-columns>
-        </many-to-one>
-        <many-to-one field="creator" target-entity="Sulu\Component\Security\Authentication\UserInterface">
-            <join-columns>
-                <join-column name="idUsersCreator" referenced-column-name="id" on-delete="SET NULL" nullable="true"/>
             </join-columns>
         </many-to-one>
 

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/doctrine/Activity.orm.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/doctrine/Activity.orm.xml
@@ -13,21 +13,6 @@
         <field name="dueDate" type="datetime" column="dueDate" nullable="false"/>
         <field name="startDate" type="datetime" column="startDate" nullable="true"/>
 
-        <field name="created" type="datetime" column="created"/>
-        <field name="changed" type="datetime" column="changed"/>
-
-        <many-to-one field="changer" target-entity="Sulu\Component\Security\Authentication\UserInterface">
-            <join-columns>
-                <join-column name="idUsersChanger" referenced-column-name="id" on-delete="SET NULL" nullable="true"/>
-            </join-columns>
-        </many-to-one>
-
-        <many-to-one field="creator" target-entity="Sulu\Component\Security\Authentication\UserInterface">
-            <join-columns>
-                <join-column name="idUsersCreator" referenced-column-name="id" on-delete="SET NULL" nullable="true"/>
-            </join-columns>
-        </many-to-one>
-
         <many-to-one field="activityStatus" target-entity="Sulu\Bundle\ContactBundle\Entity\ActivityStatus"
                      inversed-by="activities">
             <join-columns>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/doctrine/Contact.orm.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/doctrine/Contact.orm.xml
@@ -11,8 +11,6 @@
         <field name="middleName" type="string" column="middleName" length="60" nullable="true"/>
         <field name="lastName" type="string" column="lastName" length="60"/>
         <field name="birthday" type="date" column="birthday" nullable="true"/>
-        <field name="created" type="datetime" column="created"/>
-        <field name="changed" type="datetime" column="changed"/>
 
         <field name="salutation" type="string" column="salutation" length="255" nullable="true"/>
         <field name="formOfAddress" type="integer" column="formOfAddress" nullable="true"/>
@@ -38,16 +36,6 @@
 
         <one-to-many field="accountContacts" target-entity="Sulu\Bundle\ContactBundle\Entity\AccountContact" mapped-by="contact"/>
 
-        <many-to-one field="changer" target-entity="Sulu\Component\Security\Authentication\UserInterface">
-            <join-columns>
-                <join-column name="idUsersChanger" referenced-column-name="id" on-delete="SET NULL" nullable="true"/>
-            </join-columns>
-        </many-to-one>
-        <many-to-one field="creator" target-entity="Sulu\Component\Security\Authentication\UserInterface">
-            <join-columns>
-                <join-column name="idUsersCreator" referenced-column-name="id" on-delete="SET NULL" nullable="true"/>
-            </join-columns>
-        </many-to-one>
         <many-to-one field="title" target-entity="Sulu\Bundle\ContactBundle\Entity\ContactTitle">
             <join-columns>
                 <join-column name="idTitles" referenced-column-name="id" on-delete="SET NULL" nullable="true"/>

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
@@ -62,24 +62,18 @@ class AccountControllerTest extends SuluTestCase
         $account->setName('Company');
         $account->setType(Account::TYPE_BASIC);
         $account->setDisabled(0);
-        $account->setCreated(new DateTime());
-        $account->setChanged(new DateTime());
         $account->setPlaceOfJurisdiction('Feldkirch');
 
         $parentAccount = new Account();
         $parentAccount->setName('Parent');
         $parentAccount->setType(Account::TYPE_BASIC);
         $parentAccount->setDisabled(0);
-        $parentAccount->setCreated(new DateTime());
-        $parentAccount->setChanged(new DateTime());
         $parentAccount->setPlaceOfJurisdiction('Feldkirch');
 
         $childAccount = new Account();
         $childAccount->setName('Child');
         $childAccount->setType(Account::TYPE_BASIC);
         $childAccount->setDisabled(0);
-        $childAccount->setCreated(new DateTime());
-        $childAccount->setChanged(new DateTime());
         $childAccount->setPlaceOfJurisdiction('Feldkirch');
         $childAccount->setParent($parentAccount);
 
@@ -168,8 +162,6 @@ class AccountControllerTest extends SuluTestCase
         $contact->setFirstName("Vorname");
         $contact->setLastName("Nachname");
         $contact->setMiddleName("Mittelname");
-        $contact->setCreated(new \DateTime());
-        $contact->setChanged(new \DateTime());
         $contact->setDisabled(0);
         $contact->setFormOfAddress(0);
 
@@ -271,8 +263,6 @@ class AccountControllerTest extends SuluTestCase
     {
         $account = new Account();
         $account->setName('test');
-        $account->setChanged(new DateTime());
-        $account->setCreated(new DateTime());
 
         $this->em->persist($account);
         $this->em->flush();
@@ -1367,8 +1357,6 @@ class AccountControllerTest extends SuluTestCase
         $contact->setFirstName("Vorname");
         $contact->setLastName("Nachname");
         $contact->setMiddleName("Mittelname");
-        $contact->setCreated(new \DateTime());
-        $contact->setChanged(new \DateTime());
         $contact->setDisabled(0);
         $contact->setFormOfAddress(0);
         $this->em->persist($contact);
@@ -1418,8 +1406,6 @@ class AccountControllerTest extends SuluTestCase
         // modify test data
         $acc = new Account();
         $acc->setName("Test Account");
-        $acc->setChanged(new \DateTime());
-        $acc->setCreated(new \DateTime());
         $this->em->persist($acc);
 
         // add 5 contacts to account
@@ -1428,8 +1414,6 @@ class AccountControllerTest extends SuluTestCase
             $contact->setFirstName("Vorname " . $i);
             $contact->setLastName("Nachname " . $i);
             $contact->setMiddleName("Mittelname " . $i);
-            $contact->setCreated(new \DateTime());
-            $contact->setChanged(new \DateTime());
             $contact->setDisabled(0);
             $contact->setFormOfAddress(0);
             $this->em->persist($contact);
@@ -1445,8 +1429,6 @@ class AccountControllerTest extends SuluTestCase
         // add subaccount to $this->account
         $subacc = new Account();
         $subacc->setName("Subaccount");
-        $subacc->setChanged(new \DateTime());
-        $subacc->setCreated(new \DateTime());
         $subacc->setParent($this->account);
 
         $this->em->persist($subacc);
@@ -1490,8 +1472,6 @@ class AccountControllerTest extends SuluTestCase
             $contact->setFirstName("Vorname " . $i);
             $contact->setLastName("Nachname " . $i);
             $contact->setMiddleName("Mittelname " . $i);
-            $contact->setCreated(new \DateTime());
-            $contact->setChanged(new \DateTime());
             $contact->setDisabled(0);
             $contact->setFormOfAddress(0);
             $this->em->persist($contact);
@@ -1536,8 +1516,6 @@ class AccountControllerTest extends SuluTestCase
         for ($i = 0; $i < 5; $i++) {
             $childAccount = new Account();
             $childAccount->setName("child num#" . $i);
-            $childAccount->setChanged(new \DateTime());
-            $childAccount->setCreated(new \DateTime());
             $childAccount->setParent($this->account);
 
             $this->em->persist($childAccount);

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountMediaControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountMediaControllerTest.php
@@ -67,8 +67,6 @@ class AccountMediaControllerTest extends SuluTestCase
         $this->account->setName('Company');
         $this->account->setType(Account::TYPE_BASIC);
         $this->account->setDisabled(0);
-        $this->account->setCreated(new DateTime());
-        $this->account->setChanged(new DateTime());
         $this->account->setPlaceOfJurisdiction('Feldkirch');
 
         $urlType = new UrlType();
@@ -136,8 +134,6 @@ class AccountMediaControllerTest extends SuluTestCase
         $contact->setFirstName("Vorname");
         $contact->setLastName("Nachname");
         $contact->setMiddleName("Mittelname");
-        $contact->setCreated(new \DateTime());
-        $contact->setChanged(new \DateTime());
         $contact->setDisabled(0);
         $contact->setFormOfAddress(0);
 
@@ -196,15 +192,11 @@ class AccountMediaControllerTest extends SuluTestCase
         $audioType->setDescription('This is an audio');
 
         $media = new Media();
-        $media->setCreated(new DateTime());
-        $media->setChanged(new DateTime());
         $media->setType($imageType);
 
         $this->media = $media;
 
         $media2 = new Media();
-        $media2->setCreated(new DateTime());
-        $media2->setChanged(new DateTime());
         $media2->setType($imageType);
 
         $this->media2 = $media2;
@@ -214,21 +206,15 @@ class AccountMediaControllerTest extends SuluTestCase
         // create file
         $file = new File();
         $file->setVersion(1);
-        $file->setCreated(new DateTime());
-        $file->setChanged(new DateTime());
         $file->setMedia($media);
 
         $file2 = new File();
         $file2->setVersion(1);
-        $file2->setCreated(new DateTime());
-        $file2->setChanged(new DateTime());
         $file2->setMedia($media2);
 
         // create file version
         $fileVersion = new FileVersion();
         $fileVersion->setVersion(1);
-        $fileVersion->setCreated(new DateTime());
-        $fileVersion->setChanged(new DateTime());
         $fileVersion->setName('photo.jpeg');
         $fileVersion->setMimeType('image/jpg');
         $fileVersion->setFile($file);
@@ -240,8 +226,6 @@ class AccountMediaControllerTest extends SuluTestCase
         // create file version
         $fileVersion = new FileVersion();
         $fileVersion->setVersion(1);
-        $fileVersion->setCreated(new DateTime());
-        $fileVersion->setChanged(new DateTime());
         $fileVersion->setName('photo.jpeg');
         $fileVersion->setMimeType('image/jpg');
         $fileVersion->setFile($file2);
@@ -275,8 +259,6 @@ class AccountMediaControllerTest extends SuluTestCase
 
         $collection->setStyle(json_encode($style));
 
-        $collection->setCreated(new DateTime());
-        $collection->setChanged(new DateTime());
 
         // Create Collection Type
         $collectionType = new CollectionType();

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ActivityControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ActivityControllerTest.php
@@ -87,8 +87,6 @@ class ActivityControllerTest extends SuluTestCase
         $account->setName('Company');
         $account->setType(Account::TYPE_BASIC);
         $account->setDisabled(0);
-        $account->setCreated(new \DateTime());
-        $account->setChanged(new \DateTime());
         $account->setPlaceOfJurisdiction('Feldkirch');
 
         $this->account = $account;
@@ -107,8 +105,6 @@ class ActivityControllerTest extends SuluTestCase
         $contact->setFirstName("Vorname");
         $contact->setLastName("Nachname");
         $contact->setMiddleName("Mittelname");
-        $contact->setCreated(new \DateTime());
-        $contact->setChanged(new \DateTime());
         $contact->setDisabled(0);
         $contact->setFormOfAddress(0);
 
@@ -146,8 +142,6 @@ class ActivityControllerTest extends SuluTestCase
         $activity->setActivityPriority($activityPriortiy);
         $activity->setActivityStatus($activityState);
         $activity->setStartDate(new \DateTime());
-        $activity->setCreated(new \DateTime());
-        $activity->setChanged(new \DateTime());
 
         $this->activity = $activity;
 
@@ -161,8 +155,6 @@ class ActivityControllerTest extends SuluTestCase
         $activity2->setActivityPriority($activityPriortiy);
         $activity2->setActivityStatus($activityState);
         $activity2->setStartDate(new \DateTime());
-        $activity2->setCreated(new \DateTime());
-        $activity2->setChanged(new \DateTime());
 
         $this->activity2 = $activity2;
 

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
@@ -50,8 +50,6 @@ class ContactControllerTest extends SuluTestCase
         $contact->setFirstName('Max');
         $contact->setLastName('Mustermann');
         $contact->setPosition('CEO');
-        $contact->setCreated(new DateTime());
-        $contact->setChanged(new DateTime());
         $contact->setFormOfAddress(1);
         $contact->setSalutation("Sehr geehrter Herr Dr Mustermann");
         $contact->setDisabled(0);
@@ -71,8 +69,6 @@ class ContactControllerTest extends SuluTestCase
         $account->setRgt(1);
         $account->setDepth(0);
         $account->setName('Musterfirma');
-        $account->setCreated(new DateTime());
-        $account->setChanged(new DateTime());
 
         $this->account = $account;
 
@@ -81,8 +77,6 @@ class ContactControllerTest extends SuluTestCase
         $account1->setRgt(1);
         $account1->setDepth(0);
         $account1->setName('Musterfirma');
-        $account1->setCreated(new DateTime());
-        $account1->setChanged(new DateTime());
 
         $this->account1 = $account1;
 
@@ -193,8 +187,6 @@ class ContactControllerTest extends SuluTestCase
         /* First Category
         -------------------------------------*/
         $category = new Category();
-        $category->setCreated(new \DateTime());
-        $category->setChanged(new \DateTime());
         $category->setKey('first-category-key');
 
         $this->category = $category;
@@ -219,8 +211,6 @@ class ContactControllerTest extends SuluTestCase
         /* Second Category
         -------------------------------------*/
         $category2 = new Category();
-        $category2->setCreated(new \DateTime());
-        $category2->setChanged(new \DateTime());
         $category2->setKey('second-category-key');
 
         $this->category2 = $category2;

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactMediaControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactMediaControllerTest.php
@@ -51,8 +51,6 @@ class ContactMediaControllerTest extends SuluTestCase
         $contact->setFirstName('Max');
         $contact->setLastName('Mustermann');
         $contact->setPosition('CEO');
-        $contact->setCreated(new DateTime());
-        $contact->setChanged(new DateTime());
         $contact->setFormOfAddress(1);
         $contact->setSalutation("Sehr geehrter Herr Dr Mustermann");
         $contact->setDisabled(0);
@@ -72,16 +70,12 @@ class ContactMediaControllerTest extends SuluTestCase
         $account->setRgt(1);
         $account->setDepth(0);
         $account->setName('Musterfirma');
-        $account->setCreated(new DateTime());
-        $account->setChanged(new DateTime());
 
         $account1 = new Account();
         $account1->setLft(0);
         $account1->setRgt(1);
         $account1->setDepth(0);
         $account1->setName('Musterfirma');
-        $account1->setCreated(new DateTime());
-        $account1->setChanged(new DateTime());
 
         $phoneType = new PhoneType();
         $phoneType->setName('Private');
@@ -191,15 +185,11 @@ class ContactMediaControllerTest extends SuluTestCase
         $audioType->setDescription('This is an audio');
 
         $media = new Media();
-        $media->setCreated(new DateTime());
-        $media->setChanged(new DateTime());
         $media->setType($imageType);
 
         $this->media = $media;
 
         $media2 = new Media();
-        $media2->setCreated(new DateTime());
-        $media2->setChanged(new DateTime());
         $media2->setType($imageType);
 
         $this->media2 = $media2;
@@ -209,21 +199,15 @@ class ContactMediaControllerTest extends SuluTestCase
         // create file
         $file = new File();
         $file->setVersion(1);
-        $file->setCreated(new DateTime());
-        $file->setChanged(new DateTime());
         $file->setMedia($media);
 
         $file2 = new File();
         $file2->setVersion(1);
-        $file2->setCreated(new DateTime());
-        $file2->setChanged(new DateTime());
         $file2->setMedia($media2);
 
         // create file version
         $fileVersion = new FileVersion();
         $fileVersion->setVersion(1);
-        $fileVersion->setCreated(new DateTime());
-        $fileVersion->setChanged(new DateTime());
         $fileVersion->setName('photo.jpeg');
         $fileVersion->setMimeType('image/jpg');
         $fileVersion->setFile($file);
@@ -235,8 +219,6 @@ class ContactMediaControllerTest extends SuluTestCase
         // create file version
         $fileVersion = new FileVersion();
         $fileVersion->setVersion(1);
-        $fileVersion->setCreated(new DateTime());
-        $fileVersion->setChanged(new DateTime());
         $fileVersion->setName('photo.jpeg');
         $fileVersion->setMimeType('image/jpg');
         $fileVersion->setFile($file2);
@@ -270,8 +252,6 @@ class ContactMediaControllerTest extends SuluTestCase
 
         $collection->setStyle(json_encode($style));
 
-        $collection->setCreated(new DateTime());
-        $collection->setChanged(new DateTime());
 
         // Create Collection Type
         $collectionType = new CollectionType();

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Content/SmartContentQueryBuilderTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Content/SmartContentQueryBuilderTest.php
@@ -94,25 +94,19 @@ class SmartContentQueryBuilderTest extends SuluTestCase
 
         $this->tag1 = new Tag();
         $this->tag1->setName('test1');
-        $this->tag1->setChanged(new \DateTime());
         $this->tag1->setCreator($user);
-        $this->tag1->setCreated(new \DateTime());
         $this->tag1->setChanger($user);
         $em->persist($this->tag1);
 
         $this->tag2 = new Tag();
         $this->tag2->setName('test2');
-        $this->tag2->setChanged(new \DateTime());
         $this->tag2->setCreator($user);
-        $this->tag2->setCreated(new \DateTime());
         $this->tag2->setChanger($user);
         $em->persist($this->tag2);
 
         $this->tag3 = new Tag();
         $this->tag3->setName('test3');
-        $this->tag3->setChanged(new \DateTime());
         $this->tag3->setCreator($user);
-        $this->tag3->setCreated(new \DateTime());
         $this->tag3->setChanger($user);
         $em->persist($this->tag3);
 

--- a/src/Sulu/Bundle/ContentBundle/Tests/WebTests/Controller/NodeControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/WebTests/Controller/NodeControllerTest.php
@@ -39,8 +39,6 @@ class NodeControllerTest extends SuluTestCase
         $contact = new Contact();
         $contact->setFirstName('Max');
         $contact->setLastName('Mustermann');
-        $contact->setCreated(new DateTime());
-        $contact->setChanged(new DateTime());
         $this->em->persist($contact);
         $this->em->flush();
 
@@ -58,8 +56,6 @@ class NodeControllerTest extends SuluTestCase
         $role1 = new Role();
         $role1->setName('Role1');
         $role1->setSystem('Sulu');
-        $role1->setChanged(new DateTime());
-        $role1->setCreated(new DateTime());
         $this->em->persist($role1);
         $this->em->flush();
 
@@ -87,29 +83,21 @@ class NodeControllerTest extends SuluTestCase
         $this->em->flush();
 
         $tag1 = new Tag();
-        $tag1->setChanged(new DateTime());
-        $tag1->setCreated(new DateTime());
         $tag1->setName('tag1');
         $this->em->persist($tag1);
         $this->em->flush();
 
         $tag2 = new Tag();
-        $tag2->setChanged(new DateTime());
-        $tag2->setCreated(new DateTime());
         $tag2->setName('tag2');
         $this->em->persist($tag2);
         $this->em->flush();
 
         $tag3 = new Tag();
-        $tag3->setChanged(new DateTime());
-        $tag3->setCreated(new DateTime());
         $tag3->setName('tag3');
         $this->em->persist($tag3);
         $this->em->flush();
 
         $tag4 = new Tag();
-        $tag4->setChanged(new DateTime());
-        $tag4->setCreated(new DateTime());
         $tag4->setName('tag4');
         $this->em->persist($tag4);
         $this->em->flush();

--- a/src/Sulu/Bundle/ContentBundle/Tests/WebTests/Controller/PreviewControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/WebTests/Controller/PreviewControllerTest.php
@@ -59,8 +59,6 @@ class PreviewControllerTest extends SuluTestCase
         $contact = new Contact();
         $contact->setFirstName('Max');
         $contact->setLastName('Mustermann');
-        $contact->setCreated(new DateTime());
-        $contact->setChanged(new DateTime());
         $this->em->persist($contact);
 
         $emailType = new EmailType();
@@ -77,8 +75,6 @@ class PreviewControllerTest extends SuluTestCase
         $role1 = new Role();
         $role1->setName('Role1');
         $role1->setSystem('Sulu');
-        $role1->setChanged(new DateTime());
-        $role1->setCreated(new DateTime());
         $this->em->persist($role1);
 
         $user = new User();

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/RemoveForeignContextServicesPass.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/RemoveForeignContextServicesPass.php
@@ -32,7 +32,6 @@ class RemoveForeignContextServicesPass implements CompilerPassInterface
         }
 
         $taggedServices = $container->findTaggedServiceIds(self::SULU_CONTEXT_TAG);
-
         $context = $container->getParameter('sulu.context');
 
         foreach ($taggedServices as $id => $attributes) {

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -110,6 +110,7 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
         $loader->load('rest.xml');
         $loader->load('build.xml');
         $loader->load('localization.xml');
+        $loader->load('persistence.xml');
     }
 
     /**

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/persistence.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/persistence.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="sulu.persistence.event_subscriber.orm.timestampable.class">Sulu\Component\Persistence\EventSubscriber\ORM\TimestampableSubscriber</parameter>
+        <parameter key="sulu.persistence.event_subscriber.orm.user_blame.class">Sulu\Component\Persistence\EventSubscriber\ORM\UserBlameSubscriber</parameter>
+    </parameters>
+
+    <services>
+
+        <service id="sulu.persistence.event_subscriber.orm.timestampable" class="%sulu.persistence.event_subscriber.orm.timestampable.class%">
+            <tag name="doctrine.event_subscriber" />
+        </service>
+
+        <service id="sulu.persistence.event_subscriber.orm.user_blame" class="%sulu.persistence.event_subscriber.orm.user_blame.class%">
+            <argument type="service" id="security.token_storage" on-invalid="null"/>
+            <tag name="doctrine.event_subscriber" />
+        </service>
+
+    </services>
+
+</container>
+

--- a/src/Sulu/Bundle/MediaBundle/Api/Collection.php
+++ b/src/Sulu/Bundle/MediaBundle/Api/Collection.php
@@ -283,20 +283,6 @@ class Collection extends ApiWrapper
     }
 
     /**
-     * @param DateTime|string $changed
-     * @return $this
-     */
-    public function setChanged($changed)
-    {
-        if (is_string($changed)) {
-            $changed = new \DateTime($changed);
-        }
-        $this->entity->setChanged($changed);
-
-        return $this;
-    }
-
-    /**
      * @VirtualProperty
      * @SerializedName("changed")
      * @return string
@@ -330,20 +316,6 @@ class Collection extends ApiWrapper
         }
 
         return null;
-    }
-
-    /**
-     * @param DateTime|string $created
-     * @return $this
-     */
-    public function setCreated($created)
-    {
-        if (is_string($created)) {
-            $created = new \DateTime($created);
-        }
-        $this->entity->setCreated($created);
-
-        return $this;
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Api/Media.php
+++ b/src/Sulu/Bundle/MediaBundle/Api/Media.php
@@ -483,20 +483,6 @@ class Media extends ApiWrapper
     }
 
     /**
-     * @param DateTime|string $changed
-     * @return $this
-     */
-    public function setChanged($changed)
-    {
-        if (is_string($changed)) {
-            $changed = new \DateTime($changed);
-        }
-        $this->entity->setChanged($changed);
-
-        return $this;
-    }
-
-    /**
      * @VirtualProperty
      * @SerializedName("changed")
      * @return string
@@ -530,20 +516,6 @@ class Media extends ApiWrapper
         }
 
         return null;
-    }
-
-    /**
-     * @param DateTime|string $created
-     * @return $this
-     */
-    public function setCreated($created)
-    {
-        if (is_string($created)) {
-            $created = new \DateTime($created);
-        }
-        $this->entity->setCreated($created);
-
-        return $this;
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Behat/MediaContext.php
+++ b/src/Sulu/Bundle/MediaBundle/Behat/MediaContext.php
@@ -234,8 +234,6 @@ class MediaContext extends BaseContext implements SnippetAcceptingContext
         }
 
         $collection = new Collection();
-        $collection->setCreated(new \DateTime());
-        $collection->setChanged(new \DateTime());
         $collection->setType($this->getOrCreateCollectionType('Default'));
         $collectionMeta = new CollectionMeta();
         $collectionMeta->setTitle($name);

--- a/src/Sulu/Bundle/MediaBundle/Collection/Manager/DefaultCollectionManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Collection/Manager/DefaultCollectionManager.php
@@ -377,12 +377,6 @@ class DefaultCollectionManager implements CollectionManagerInterface
                         $type = $this->getTypeById($value['id']);
                         $collection->setType($type);
                         break;
-                    case 'changed':
-                        $collection->setChanged($value);
-                        break;
-                    case 'created':
-                        $collection->setCreated($value);
-                        break;
                     case 'changer':
                         $collection->setChanger($value);
                         break;

--- a/src/Sulu/Bundle/MediaBundle/Entity/BaseCollection.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/BaseCollection.php
@@ -11,6 +11,7 @@
 namespace Sulu\Bundle\MediaBundle\Entity;
 
 use JMS\Serializer\Annotation\Exclude;
+use Sulu\Component\Persistence\Model\AuditableInterface;
 
 /**
  * BaseCollection
@@ -221,19 +222,6 @@ abstract class BaseCollection implements CollectionInterface
     }
 
     /**
-     * Set created
-     *
-     * @param \DateTime $created
-     * @return CollectionInterface
-     */
-    public function setCreated($created)
-    {
-        $this->created = $created;
-
-        return $this;
-    }
-
-    /**
      * Get created
      *
      * @return \DateTime
@@ -241,19 +229,6 @@ abstract class BaseCollection implements CollectionInterface
     public function getCreated()
     {
         return $this->created;
-    }
-
-    /**
-     * Set changed
-     *
-     * @param \DateTime $changed
-     * @return CollectionInterface
-     */
-    public function setChanged($changed)
-    {
-        $this->changed = $changed;
-
-        return $this;
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Entity/CollectionInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/CollectionInterface.php
@@ -11,11 +11,12 @@
 namespace Sulu\Bundle\MediaBundle\Entity;
 
 use JMS\Serializer\Annotation\Exclude;
+use Sulu\Component\Persistence\Model\AuditableInterface;
 
 /**
  * CollectionInterface
  */
-interface CollectionInterface
+interface CollectionInterface extends AuditableInterface
 {
     /**
      * Get id
@@ -115,27 +116,11 @@ interface CollectionInterface
     public function getDepth();
 
     /**
-     * Set created
-     *
-     * @param \DateTime $created
-     * @return CollectionInterface
-     */
-    public function setCreated($created);
-
-    /**
      * Get created
      *
      * @return \DateTime
      */
     public function getCreated();
-
-    /**
-     * Set changed
-     *
-     * @param \DateTime $changed
-     * @return CollectionInterface
-     */
-    public function setChanged($changed);
 
     /**
      * Get changed

--- a/src/Sulu/Bundle/MediaBundle/Entity/File.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/File.php
@@ -10,11 +10,13 @@
 
 namespace Sulu\Bundle\MediaBundle\Entity;
 
+use Sulu\Component\Persistence\Model\AuditableInterface;
+
 /**
  * File
  */
-class File
-{
+class File implements AuditableInterface
+{ 
     /**
      * @var \DateTime
      */
@@ -64,19 +66,6 @@ class File
     }
 
     /**
-     * Set created
-     *
-     * @param \DateTime $created
-     * @return File
-     */
-    public function setCreated($created)
-    {
-        $this->created = $created;
-
-        return $this;
-    }
-
-    /**
      * Get created
      *
      * @return \DateTime
@@ -84,19 +73,6 @@ class File
     public function getCreated()
     {
         return $this->created;
-    }
-
-    /**
-     * Set changed
-     *
-     * @param \DateTime $changed
-     * @return File
-     */
-    public function setChanged($changed)
-    {
-        $this->changed = $changed;
-
-        return $this;
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Entity/FileVersion.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/FileVersion.php
@@ -11,11 +11,12 @@
 namespace Sulu\Bundle\MediaBundle\Entity;
 
 use JMS\Serializer\Annotation\Exclude;
+use Sulu\Component\Persistence\Model\AuditableInterface;
 
 /**
  * FileVersion
  */
-class FileVersion
+class FileVersion implements AuditableInterface
 {
 
     /**
@@ -249,19 +250,6 @@ class FileVersion
     }
 
     /**
-     * Set created
-     *
-     * @param \DateTime $created
-     * @return FileVersion
-     */
-    public function setCreated($created)
-    {
-        $this->created = $created;
-
-        return $this;
-    }
-
-    /**
      * Get created
      *
      * @return \DateTime
@@ -269,19 +257,6 @@ class FileVersion
     public function getCreated()
     {
         return $this->created;
-    }
-
-    /**
-     * Set changed
-     *
-     * @param \DateTime $changed
-     * @return FileVersion
-     */
-    public function setChanged($changed)
-    {
-        $this->changed = $changed;
-
-        return $this;
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Entity/Media.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/Media.php
@@ -11,11 +11,12 @@
 namespace Sulu\Bundle\MediaBundle\Entity;
 
 use JMS\Serializer\Annotation\Exclude;
+use Sulu\Component\Persistence\Model\AuditableInterface;
 
 /**
  * Media
  */
-class Media
+class Media implements AuditableInterface
 {
     /**
      * @var \DateTime
@@ -67,19 +68,6 @@ class Media
     }
 
     /**
-     * Set created
-     *
-     * @param \DateTime $created
-     * @return Media
-     */
-    public function setCreated($created)
-    {
-        $this->created = $created;
-
-        return $this;
-    }
-
-    /**
      * Get created
      *
      * @return \DateTime
@@ -87,19 +75,6 @@ class Media
     public function getCreated()
     {
         return $this->created;
-    }
-
-    /**
-     * Set changed
-     *
-     * @param \DateTime $changed
-     * @return Media
-     */
-    public function setChanged($changed)
-    {
-        $this->changed = $changed;
-
-        return $this;
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/DefaultMediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/DefaultMediaManager.php
@@ -438,7 +438,6 @@ class DefaultMediaManager implements MediaManagerInterface
             throw new MediaNotFoundException('Media with the ID ' . $data['id'] . ' not found');
         }
 
-        $mediaEntity->setChanged(new \DateTime());
         $mediaEntity->setChanger($user);
 
         $files = $mediaEntity->getFiles();
@@ -451,7 +450,6 @@ class DefaultMediaManager implements MediaManagerInterface
          */
         $file = $files[0]; // currently a media can only have one file
 
-        $file->setChanged(new \Datetime());
         $file->setChanger($user);
 
         $version = $file->getVersion();
@@ -492,8 +490,6 @@ class DefaultMediaManager implements MediaManagerInterface
             $data['version'] = $version;
 
             $fileVersion = clone($currentFileVersion);
-            $fileVersion->setChanged(new \Datetime());
-            $fileVersion->setCreated(new \Datetime());
             $fileVersion->setChanger($user);
             $fileVersion->setCreator($user);
             $fileVersion->setDownloadCounter(0);
@@ -575,22 +571,16 @@ class DefaultMediaManager implements MediaManagerInterface
         $mediaEntity = new MediaEntity();
         $mediaEntity->setCreator($user);
         $mediaEntity->setChanger($user);
-        $mediaEntity->setCreated(new \DateTime());
-        $mediaEntity->setChanged(new \DateTime());
 
         $file = new File();
         $file->setCreator($user);
         $file->setChanger($user);
-        $file->setCreated(new \DateTime());
-        $file->setChanged(new \DateTime());
         $file->setVersion(1);
         $file->setMedia($mediaEntity);
 
         $fileVersion = new FileVersion();
         $fileVersion->setCreator($user);
         $fileVersion->setChanger($user);
-        $fileVersion->setCreated(new \DateTime());
-        $fileVersion->setChanged(new \DateTime());
         $fileVersion->setVersion(1);
         $fileVersion->setFile($file);
 
@@ -689,10 +679,8 @@ class DefaultMediaManager implements MediaManagerInterface
                         $media->setProperties($value);
                         break;
                     case 'changed':
-                        $media->setChanged($value);
                         break;
                     case 'created':
-                        $media->setCreated($value);
                         break;
                     case 'changer':
                         if ($value instanceof UserInterface) {

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/BaseCollection.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/BaseCollection.orm.xml
@@ -18,22 +18,10 @@
         <field name="depth" type="integer" column="depth">
             <gedmo:tree-level/>
         </field>
-        <field name="created" type="datetime" column="created"/>
-        <field name="changed" type="datetime" column="changed"/>
 
         <many-to-one field="type" target-entity="Sulu\Bundle\MediaBundle\Entity\CollectionType" inversed-by="collections">
             <join-columns>
                 <join-column name="idCollectionTypes" referenced-column-name="id" nullable="false"/>
-            </join-columns>
-        </many-to-one>
-        <many-to-one field="changer" target-entity="Sulu\Component\Security\Authentication\UserInterface">
-            <join-columns>
-                <join-column name="idUsersChanger" referenced-column-name="id" on-delete="SET NULL" nullable="true"/>
-            </join-columns>
-        </many-to-one>
-        <many-to-one field="creator" target-entity="Sulu\Component\Security\Authentication\UserInterface">
-            <join-columns>
-                <join-column name="idUsersCreator" referenced-column-name="id" on-delete="SET NULL" nullable="true"/>
             </join-columns>
         </many-to-one>
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/File.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/File.orm.xml
@@ -8,8 +8,6 @@
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>
-        <field name="created" type="datetime" column="created"/>
-        <field name="changed" type="datetime" column="changed"/>
         <field name="version" type="integer" column="version" />
         <one-to-many field="fileVersions" target-entity="Sulu\Bundle\MediaBundle\Entity\FileVersion" mapped-by="file">
             <cascade>
@@ -19,16 +17,6 @@
         <many-to-one field="media" target-entity="Sulu\Bundle\MediaBundle\Entity\Media" inversed-by="files">
             <join-columns>
                 <join-column name="idMedia" referenced-column-name="id" on-delete="CASCADE" nullable="false"/>
-            </join-columns>
-        </many-to-one>
-        <many-to-one field="changer" target-entity="Sulu\Component\Security\Authentication\UserInterface">
-            <join-columns>
-                <join-column name="idUsersChanger" referenced-column-name="id" on-delete="SET NULL" nullable="true"/>
-            </join-columns>
-        </many-to-one>
-        <many-to-one field="creator" target-entity="Sulu\Component\Security\Authentication\UserInterface">
-            <join-columns>
-                <join-column name="idUsersCreator" referenced-column-name="id" on-delete="SET NULL" nullable="true"/>
             </join-columns>
         </many-to-one>
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersion.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersion.orm.xml
@@ -19,9 +19,6 @@
         <field name="storageOptions" type="text" column="storageOptions" nullable="true" />
         <field name="mimeType" type="string" column="mimeType" length="255" nullable="true" />
 
-        <field name="created" type="datetime" column="created"/>
-        <field name="changed" type="datetime" column="changed"/>
-
         <one-to-many field="contentLanguages" target-entity="Sulu\Bundle\MediaBundle\Entity\FileVersionContentLanguage" mapped-by="fileVersion">
             <cascade>
                 <cascade-persist />
@@ -41,16 +38,6 @@
         <many-to-one field="file" target-entity="Sulu\Bundle\MediaBundle\Entity\File" inversed-by="fileVersions">
             <join-columns>
                 <join-column name="idFiles" referenced-column-name="id" on-delete="CASCADE" nullable="true"/>
-            </join-columns>
-        </many-to-one>
-        <many-to-one field="changer" target-entity="Sulu\Component\Security\Authentication\UserInterface">
-            <join-columns>
-                <join-column name="idUsersChanger" referenced-column-name="id" on-delete="SET NULL" nullable="true"/>
-            </join-columns>
-        </many-to-one>
-        <many-to-one field="creator" target-entity="Sulu\Component\Security\Authentication\UserInterface">
-            <join-columns>
-                <join-column name="idUsersCreator" referenced-column-name="id" on-delete="SET NULL" nullable="true"/>
             </join-columns>
         </many-to-one>
         <many-to-many field="tags" target-entity="Sulu\Bundle\TagBundle\Entity\Tag">

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/Media.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/Media.orm.xml
@@ -8,8 +8,6 @@
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>
-        <field name="created" type="datetime" column="created"/>
-        <field name="changed" type="datetime" column="changed"/>
 
         <one-to-many field="files" target-entity="Sulu\Bundle\MediaBundle\Entity\File" mapped-by="media">
             <cascade>
@@ -25,16 +23,6 @@
         <many-to-one field="type" target-entity="Sulu\Bundle\MediaBundle\Entity\MediaType" inversed-by="media">
             <join-columns>
                 <join-column name="idMediaTypes" referenced-column-name="id" nullable="false"/>
-            </join-columns>
-        </many-to-one>
-        <many-to-one field="changer" target-entity="Sulu\Component\Security\Authentication\UserInterface">
-            <join-columns>
-                <join-column name="idUsersChanger" referenced-column-name="id" on-delete="SET NULL" nullable="true"/>
-            </join-columns>
-        </many-to-one>
-        <many-to-one field="creator" target-entity="Sulu\Component\Security\Authentication\UserInterface">
-            <join-columns>
-                <join-column name="idUsersCreator" referenced-column-name="id" on-delete="SET NULL" nullable="true"/>
             </join-columns>
         </many-to-one>
     </entity>

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
@@ -39,8 +39,6 @@ class CollectionControllerTest extends SuluTestCase
 
         $collection->setStyle(json_encode($style));
 
-        $collection->setCreated(new DateTime());
-        $collection->setChanged(new DateTime());
         $this->collection1 = $collection;
 
         // Create Collection Type

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
@@ -124,13 +124,9 @@ class MediaControllerTest extends SuluTestCase
 
         // create some tags
         $tag1 = new Tag();
-        $tag1->setCreated(new DateTime());
-        $tag1->setChanged(new DateTime());
         $tag1->setName('Tag 1');
 
         $tag2 = new Tag();
-        $tag2->setCreated(new DateTime());
-        $tag2->setChanged(new DateTime());
         $tag2->setName('Tag 2');
 
         $this->em->persist($tag1);
@@ -145,22 +141,16 @@ class MediaControllerTest extends SuluTestCase
     protected function createMedia($name)
     {
         $media = new Media();
-        $media->setCreated(new DateTime());
-        $media->setChanged(new DateTime());
         $media->setType($this->imageType);
 
         // create file
         $file = new File();
         $file->setVersion(1);
-        $file->setCreated(new DateTime());
-        $file->setChanged(new DateTime());
         $file->setMedia($media);
 
         // create file version
         $fileVersion = new FileVersion();
         $fileVersion->setVersion(1);
-        $fileVersion->setCreated(new DateTime());
-        $fileVersion->setChanged(new DateTime());
         $fileVersion->setName($name . '.jpeg');
         $fileVersion->setMimeType('image/jpg');
         $fileVersion->setFile($file);
@@ -205,9 +195,6 @@ class MediaControllerTest extends SuluTestCase
         );
 
         $this->collection->setStyle(json_encode($style));
-
-        $this->collection->setCreated(new DateTime());
-        $this->collection->setChanged(new DateTime());
 
         // Create Collection Type
         $this->collectionType = new CollectionType();
@@ -877,9 +864,6 @@ class MediaControllerTest extends SuluTestCase
         );
 
         $destCollection->setStyle(json_encode($style));
-
-        $destCollection->setCreated(new DateTime());
-        $destCollection->setChanged(new DateTime());
         $destCollection->setType($this->collectionType);
         $destCollection->addMeta($this->collectionMeta);
 

--- a/src/Sulu/Bundle/SearchBundle/Tests/Functional/WebsiteIntegrationTest.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Functional/WebsiteIntegrationTest.php
@@ -22,8 +22,8 @@ class WebsiteIntegrationTest extends BaseTestCase
     {
         parent::setUp();
 
-        $this->indexStructure('Structure', '/structure');
         $this->client = $this->createWebsiteClient();
+        $this->indexStructure('Structure', '/structure');
     }
 
     public function testIntegration()

--- a/src/Sulu/Bundle/SecurityBundle/Behat/SecurityContext.php
+++ b/src/Sulu/Bundle/SecurityBundle/Behat/SecurityContext.php
@@ -124,9 +124,6 @@ class SecurityContext extends BaseContext implements SnippetAcceptingContext
         $role = new Role();
         $role->setName($name);
         $role->setSystem($system);
-        $role->setCreated(new \DateTime());
-        $role->setChanged(new \DateTime());
-
         $pool = $this->getContainer()->get('sulu_admin.admin_pool');
         $securityContexts = $pool->getSecurityContexts();
 

--- a/src/Sulu/Bundle/SecurityBundle/Command/CreateRoleCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/CreateRoleCommand.php
@@ -63,8 +63,6 @@ class CreateRoleCommand extends ContainerAwareCommand
         $role = new Role();
         $role->setName($name);
         $role->setSystem($system);
-        $role->setCreated($now);
-        $role->setChanged($now);
 
         $pool = $this->getContainer()->get('sulu_admin.admin_pool');
         $securityContexts = $pool->getSecurityContexts();

--- a/src/Sulu/Bundle/SecurityBundle/Command/CreateUserCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/CreateUserCommand.php
@@ -94,8 +94,6 @@ class CreateUserCommand extends ContainerAwareCommand
         $contact = new Contact();
         $contact->setFirstName($firstName);
         $contact->setLastName($lastName);
-        $contact->setCreated($now);
-        $contact->setChanged($now);
 
         $em->persist($contact);
         $em->flush();

--- a/src/Sulu/Bundle/SecurityBundle/Controller/GroupController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/GroupController.php
@@ -129,8 +129,6 @@ class GroupController extends RestController implements ClassResourceInterface, 
 
             $this->setParent($group);
 
-            $group->setCreated(new \DateTime());
-            $group->setChanged(new \DateTime());
 
             $roles = $request->get('roles');
             if (!empty($roles)) {
@@ -175,7 +173,6 @@ class GroupController extends RestController implements ClassResourceInterface, 
 
                 $this->setParent($group);
 
-                $group->setChanged(new \DateTime());
 
                 if (!$this->processRoles($group, $request->get('roles', array()))) {
                     throw new RestException('Could not update dependencies!');

--- a/src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
@@ -211,8 +211,6 @@ class RoleController extends RestController implements ClassResourceInterface, S
             $role->setName($name);
             $role->setSystem($system);
 
-            $role->setCreated(new \DateTime());
-            $role->setChanged(new \DateTime());
 
             $permissions = $request->get('permissions');
             if (!empty($permissions)) {
@@ -265,7 +263,6 @@ class RoleController extends RestController implements ClassResourceInterface, S
                 $role->setName($name);
                 $role->setSystem($request->get('system'));
 
-                $role->setChanged(new \DateTime());
 
                 if (!$this->processPermissions($role, $request->get('permissions', array()))) {
                     throw new RestException("Could not update dependencies!");

--- a/src/Sulu/Bundle/SecurityBundle/Entity/BaseRole.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/BaseRole.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\SecurityBundle\Entity;
 use Sulu\Component\Security\Authentication\RoleInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Symfony\Component\Security\Core\Role\Role;
+use Sulu\Component\Persistence\Model\AuditableInterface;
 
 /**
  * BaseRole
@@ -116,19 +117,6 @@ abstract class BaseRole extends Role implements RoleInterface
     }
 
     /**
-     * Set created
-     *
-     * @param \DateTime $created
-     * @return BaseRole
-     */
-    public function setCreated($created)
-    {
-        $this->created = $created;
-
-        return $this;
-    }
-
-    /**
      * Get created
      *
      * @return \DateTime
@@ -136,19 +124,6 @@ abstract class BaseRole extends Role implements RoleInterface
     public function getCreated()
     {
         return $this->created;
-    }
-
-    /**
-     * Set changed
-     *
-     * @param \DateTime $changed
-     * @return BaseRole
-     */
-    public function setChanged($changed)
-    {
-        $this->changed = $changed;
-
-        return $this;
     }
 
     /**

--- a/src/Sulu/Bundle/SecurityBundle/Entity/Group.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/Group.php
@@ -13,11 +13,12 @@ namespace Sulu\Bundle\SecurityBundle\Entity;
 use Sulu\Bundle\CoreBundle\Entity\ApiEntity;
 use Sulu\Component\Security\Authentication\RoleInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
+use Sulu\Component\Persistence\Model\AuditableInterface;
 
 /**
  * Group
  */
-class Group extends ApiEntity
+class Group extends ApiEntity implements AuditableInterface
 {
     /**
      * @var integer
@@ -187,19 +188,6 @@ class Group extends ApiEntity
     }
 
     /**
-     * Set created
-     *
-     * @param \DateTime $created
-     * @return Group
-     */
-    public function setCreated($created)
-    {
-        $this->created = $created;
-
-        return $this;
-    }
-
-    /**
      * Get created
      *
      * @return \DateTime
@@ -207,19 +195,6 @@ class Group extends ApiEntity
     public function getCreated()
     {
         return $this->created;
-    }
-
-    /**
-     * Set changed
-     *
-     * @param \DateTime $changed
-     * @return Group
-     */
-    public function setChanged($changed)
-    {
-        $this->changed = $changed;
-
-        return $this;
     }
 
     /**

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/BaseRole.orm.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/BaseRole.orm.xml
@@ -9,19 +9,7 @@
 
         <field name="name" type="string" column="name" length="60" unique="true"/>
         <field name="system" type="string" column="system" length="60"/>
-        <field name="created" type="datetime" column="created"/>
-        <field name="changed" type="datetime" column="changed"/>
 
-        <many-to-one field="changer" target-entity="Sulu\Component\Security\Authentication\UserInterface">
-            <join-columns>
-                <join-column name="idUsersChanger" referenced-column-name="id" on-delete="SET NULL" nullable="true"/>
-            </join-columns>
-        </many-to-one>
-        <many-to-one field="creator" target-entity="Sulu\Component\Security\Authentication\UserInterface">
-            <join-columns>
-                <join-column name="idUsersCreator" referenced-column-name="id" on-delete="SET NULL" nullable="true"/>
-            </join-columns>
-        </many-to-one>
         <many-to-one field="securityType" target-entity="Sulu\Bundle\SecurityBundle\Entity\SecurityType">
             <join-columns>
                 <join-column name="idSecurityTypes" referenced-column-name="id" on-delete="SET NULL" nullable="true"/>

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/Group.orm.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/Group.orm.xml
@@ -18,8 +18,6 @@
             <gedmo:tree-level/>
         </field>
         <field name="name" type="string" column="name" length="60"/>
-        <field name="created" type="datetime" column="created"/>
-        <field name="changed" type="datetime" column="changed"/>
 
         <one-to-many field="children" target-entity="Sulu\Bundle\SecurityBundle\Entity\Group" mapped-by="parent"/>
         <one-to-many field="userGroups" target-entity="Sulu\Bundle\SecurityBundle\Entity\UserGroup" mapped-by="group"/>
@@ -29,16 +27,6 @@
                 <join-column name="idGroupsParent" referenced-column-name="id"/>
             </join-columns>
             <gedmo:tree-parent/>
-        </many-to-one>
-        <many-to-one field="changer" target-entity="Sulu\Component\Security\Authentication\UserInterface">
-            <join-columns>
-                <join-column name="idUsersChanger" referenced-column-name="id" on-delete="SET NULL" nullable="true"/>
-            </join-columns>
-        </many-to-one>
-        <many-to-one field="creator" target-entity="Sulu\Component\Security\Authentication\UserInterface">
-            <join-columns>
-                <join-column name="idUsersCreator" referenced-column-name="id" on-delete="SET NULL" nullable="true"/>
-            </join-columns>
         </many-to-one>
 
         <many-to-many field="roles" target-entity="Sulu\Component\Security\Authentication\RoleInterface" inversed-by="groups">

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Command/CreateUserCommandTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Command/CreateUserCommandTest.php
@@ -90,8 +90,6 @@ class CreateUserCommandTest extends SuluTestCase
         $role = new Role();
         $role->setName($roleName);
         $role->setSystem('Sulu');
-        $role->setCreated($now);
-        $role->setChanged($now);
 
         $em->persist($role);
         $em->flush();

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/GroupControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/GroupControllerTest.php
@@ -46,23 +46,17 @@ class GroupControllerTest extends SuluTestCase
         $role1 = new Role();
         $role1->setName('Sulu Administrator');
         $role1->setSystem('Sulu');
-        $role1->setCreated($datetime);
-        $role1->setChanged($datetime);
         $this->em->persist($role1);
         $this->role1 = $role1;
 
         $role2 = new Role();
         $role2->setName('Sulu Manager');
         $role2->setSystem('Sulu');
-        $role2->setCreated($datetime);
-        $role2->setChanged($datetime);
         $this->em->persist($role2);
         $this->role2 = $role2;
 
         $group1 = new Group();
         $group1->setName('Group1');
-        $group1->setCreated($datetime);
-        $group1->setChanged($datetime);
         $group1->addRole($role1);
         $group1->addRole($role2);
         $this->em->persist($group1);
@@ -70,8 +64,6 @@ class GroupControllerTest extends SuluTestCase
 
         $group2 = new Group();
         $group2->setName('Group2');
-        $group2->setCreated($datetime);
-        $group2->setChanged($datetime);
         $group2->addRole($role1);
         $this->em->persist($group2);
         $this->group2 = $group2;

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
@@ -45,8 +45,6 @@ class RoleControllerTest extends SuluTestCase
         $role = new Role();
         $role->setName('Sulu Administrator');
         $role->setSystem('Sulu');
-        $role->setCreated(new DateTime());
-        $role->setChanged(new DateTime());
         $role->setSecurityType($this->securityType1);
         $this->em->persist($role);
         $this->role1 = $role;
@@ -54,8 +52,6 @@ class RoleControllerTest extends SuluTestCase
         $role2 = new Role();
         $role2->setName('Sulu Editor');
         $role2->setSystem('Sulu');
-        $role2->setCreated(new DateTime());
-        $role2->setChanged(new DateTime());
         $this->em->persist($role2);
         $this->role2 = $role2;
 

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/UserControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/UserControllerTest.php
@@ -42,8 +42,6 @@ class UserControllerTest extends SuluTestCase
         $contact1 = new Contact();
         $contact1->setFirstName('Max');
         $contact1->setLastName('Mustermann');
-        $contact1->setCreated(new DateTime());
-        $contact1->setChanged(new DateTime());
         $contact1->addEmail($email1);
         $this->em->persist($contact1);
         $this->contact1 = $contact1;
@@ -56,8 +54,6 @@ class UserControllerTest extends SuluTestCase
         $contact2 = new Contact();
         $contact2->setFirstName("Max");
         $contact2->setLastName("Muster");
-        $contact2->setCreated(new DateTime());
-        $contact2->setChanged(new DateTime());
         $contact2->addEmail($email);
         $this->em->persist($contact2);
         $this->contact2 = $contact2;
@@ -65,8 +61,6 @@ class UserControllerTest extends SuluTestCase
         $contact3 = new Contact();
         $contact3->setFirstName("Disabled");
         $contact3->setLastName("User");
-        $contact3->setCreated(new DateTime());
-        $contact3->setChanged(new DateTime());
         $contact3->addEmail($email);
         $this->em->persist($contact3);
         $this->contact3 = $contact3;
@@ -76,16 +70,12 @@ class UserControllerTest extends SuluTestCase
         $role1 = new Role();
         $role1->setName('Role1');
         $role1->setSystem('Sulu');
-        $role1->setChanged(new DateTime());
-        $role1->setCreated(new DateTime());
         $this->em->persist($role1);
         $this->role1 = $role1;
 
         $role2 = new Role();
         $role2->setName('Role2');
         $role2->setSystem('Sulu');
-        $role2->setChanged(new DateTime());
-        $role2->setCreated(new DateTime());
         $this->em->persist($role2);
         $this->role2 = $role2;
 
@@ -150,8 +140,6 @@ class UserControllerTest extends SuluTestCase
         $group1->setLft(0);
         $group1->setRgt(0);
         $group1->setDepth(0);
-        $group1->setCreated(new DateTime());
-        $group1->setChanged(new DateTime());
         $this->em->persist($group1);
         $this->group1 = $group1;
 
@@ -160,8 +148,6 @@ class UserControllerTest extends SuluTestCase
         $group2->setLft(0);
         $group2->setRgt(0);
         $group2->setDepth(0);
-        $group2->setCreated(new DateTime());
-        $group2->setChanged(new DateTime());
         $this->em->persist($group2);
         $this->group2 = $group2;
 

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Entity/UserRepositoryTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Entity/UserRepositoryTest.php
@@ -50,16 +50,12 @@ class UserRepositoryTest extends SuluTestCase
         $contact1 = new Contact();
         $contact1->setFirstName('Max');
         $contact1->setLastName('Muster');
-        $contact1->setCreated(new DateTime());
-        $contact1->setChanged(new DateTime());
         $contact1->addEmail($email);
         $this->em->persist($contact1);
 
         $contact2 = new Contact();
         $contact2->setFirstName('Maria');
         $contact2->setLastName('Musterfrau');
-        $contact2->setCreated(new DateTime());
-        $contact2->setChanged(new DateTime());
         $contact2->addEmail($email2);
         $this->em->persist($contact2);
 
@@ -68,15 +64,11 @@ class UserRepositoryTest extends SuluTestCase
         $role1 = new Role();
         $role1->setName('Role1');
         $role1->setSystem('Sulu');
-        $role1->setChanged(new DateTime());
-        $role1->setCreated(new DateTime());
         $this->em->persist($role1);
 
         $role2 = new Role();
         $role2->setName('Role2');
         $role2->setSystem('Test');
-        $role2->setChanged(new DateTime());
-        $role2->setCreated(new DateTime());
         $this->em->persist($role2);
 
         // User 1
@@ -132,8 +124,6 @@ class UserRepositoryTest extends SuluTestCase
         $group1->setLft(0);
         $group1->setRgt(0);
         $group1->setDepth(0);
-        $group1->setCreated(new DateTime());
-        $group1->setChanged(new DateTime());
         $this->em->persist($group1);
 
         $group2 = new Group();
@@ -141,8 +131,6 @@ class UserRepositoryTest extends SuluTestCase
         $group2->setLft(0);
         $group2->setRgt(0);
         $group2->setDepth(0);
-        $group2->setCreated(new DateTime());
-        $group2->setChanged(new DateTime());
         $this->em->persist($group2);
 
         $this->em->flush();
@@ -273,8 +261,6 @@ class UserRepositoryTest extends SuluTestCase
         $contact1 = new Contact();
         $contact1->setFirstName('Max');
         $contact1->setLastName('Muster');
-        $contact1->setCreated(new DateTime());
-        $contact1->setChanged(new DateTime());
         $contact1->addEmail($email);
         $this->em->persist($contact1);
 
@@ -291,8 +277,6 @@ class UserRepositoryTest extends SuluTestCase
         $role = new Role();
         $role->setName('Sulu');
         $role->setSystem('Sulu');
-        $role->setCreated(new DateTime());
-        $role->setChanged(new DateTime());
         $this->em->persist($role);
 
         $userRole = new UserRole();

--- a/src/Sulu/Bundle/TagBundle/Behat/TagContext.php
+++ b/src/Sulu/Bundle/TagBundle/Behat/TagContext.php
@@ -29,8 +29,6 @@ class TagContext extends BaseContext implements SnippetAcceptingContext
         foreach ($node as $row) {
             $tag = new Tag();
             $tag->setName($row['name']);
-            $tag->setChanged(new \DateTime());
-            $tag->setCreated(new \DateTime());
             $this->getEntityManager()->persist($tag);
         }
 

--- a/src/Sulu/Bundle/TagBundle/Entity/Tag.php
+++ b/src/Sulu/Bundle/TagBundle/Entity/Tag.php
@@ -14,11 +14,12 @@ use Sulu\Bundle\CoreBundle\Entity\ApiEntity;
 use JMS\Serializer\Annotation\VirtualProperty;
 use JMS\Serializer\Annotation\SerializedName;
 use JMS\Serializer\Annotation\Groups;
+use Sulu\Component\Persistence\Model\AuditableInterface;
 
 /**
  * Tag
  */
-class Tag extends ApiEntity
+class Tag extends ApiEntity implements AuditableInterface
 {
     /**
      * @var string
@@ -100,19 +101,6 @@ class Tag extends ApiEntity
     }
 
     /**
-     * Set created
-     *
-     * @param \DateTime $created
-     * @return Tag
-     */
-    public function setCreated($created)
-    {
-        $this->created = $created;
-
-        return $this;
-    }
-
-    /**
      * Get created
      *
      * @return \DateTime
@@ -120,19 +108,6 @@ class Tag extends ApiEntity
     public function getCreated()
     {
         return $this->created;
-    }
-
-    /**
-     * Set changed
-     *
-     * @param \DateTime $changed
-     * @return Tag
-     */
-    public function setChanged($changed)
-    {
-        $this->changed = $changed;
-
-        return $this;
     }
 
     /**

--- a/src/Sulu/Bundle/TagBundle/Resources/config/doctrine/Tag.orm.xml
+++ b/src/Sulu/Bundle/TagBundle/Resources/config/doctrine/Tag.orm.xml
@@ -7,18 +7,6 @@
             <generator strategy="AUTO" />
         </id>
         <field name="name" type="string" column="name" unique="true" />
-        <field name="created" type="datetime" column="created"/>
-        <field name="changed" type="datetime" column="changed"/>
 
-        <many-to-one field="changer" target-entity="Sulu\Component\Security\Authentication\UserInterface">
-            <join-columns>
-                <join-column name="idUsersChanger" referenced-column-name="id" on-delete="SET NULL" nullable="true"/>
-            </join-columns>
-        </many-to-one>
-        <many-to-one field="creator" target-entity="Sulu\Component\Security\Authentication\UserInterface">
-            <join-columns>
-                <join-column name="idUsersCreator" referenced-column-name="id" on-delete="SET NULL" nullable="true"/>
-            </join-columns>
-        </many-to-one>
     </entity>
 </doctrine-mapping>

--- a/src/Sulu/Bundle/TagBundle/Tag/TagManager.php
+++ b/src/Sulu/Bundle/TagBundle/Tag/TagManager.php
@@ -157,11 +157,9 @@ class TagManager implements TagManagerInterface
 
             // update data
             $tag->setName($name);
-            $tag->setChanged(new \DateTime());
             $tag->setChanger($user);
 
             if (!$id) {
-                $tag->setCreated(new \DateTime());
                 $tag->setCreator($user);
                 $this->em->persist($tag);
             }

--- a/src/Sulu/Bundle/TagBundle/Tests/Functional/Controller/TagControllerTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Functional/Controller/TagControllerTest.php
@@ -31,15 +31,11 @@ class TagControllerTest extends SuluTestCase
 
         $tag1 = new Tag();
         $tag1->setName('tag1');
-        $tag1->setCreated(new \DateTime());
-        $tag1->setChanged(new \DateTime());
         $this->em->persist($tag1);
         $this->tag1 = $tag1;
 
         $tag2 = new Tag();
         $tag2->setName('tag2');
-        $tag2->setCreated(new \DateTime());
-        $tag2->setChanged(new \DateTime());
         $this->em->persist($tag2);
         $this->tag2 = $tag2;
 
@@ -241,14 +237,10 @@ class TagControllerTest extends SuluTestCase
     {
         $tag3 = new Tag();
         $tag3->setName('tag3');
-        $tag3->setCreated(new \DateTime());
-        $tag3->setChanged(new \DateTime());
         $this->em->persist($tag3);
 
         $tag4 = new Tag();
         $tag4->setName('tag4');
-        $tag4->setCreated(new \DateTime());
-        $tag4->setChanged(new \DateTime());
         $this->em->persist($tag4);
 
         $this->em->flush();

--- a/src/Sulu/Bundle/TranslateBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/TranslateBundle/phpunit.xml.dist
@@ -18,8 +18,6 @@
     </filter>
 
     <php>
-        <server name="KERNEL_DIR" value="Tests/app"/>
-        <var name="APP_DB" value="mysql"/>
     </php>
 
 </phpunit>

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentTwigExtensionTest.php
@@ -36,8 +36,6 @@ class TestStructure extends Structure
         $this->setUuid($uuid);
         $this->setCreator($userId);
         $this->setChanger($userId);
-        $this->setCreated(new \DateTime());
-        $this->setChanged(new \DateTime());
 
         $this->addChild(new Property('title', array(), 'text_line'));
         $this->getProperty('title')->setValue($title);
@@ -165,8 +163,6 @@ class ContentTwigExtensionTest extends ProphecyTestCase
         // metadata
         $this->assertEquals(1, $result['creator']);
         $this->assertEquals(1, $result['changer']);
-        $this->assertInstanceOf('\DateTime', $result['created']);
-        $this->assertInstanceOf('\DateTime', $result['changed']);
 
         // content
         $this->assertEquals(array('title' => 'test'), $result['content']);
@@ -195,8 +191,6 @@ class ContentTwigExtensionTest extends ProphecyTestCase
         // metadata
         $this->assertEquals(1, $result['creator']);
         $this->assertEquals(1, $result['changer']);
-        $this->assertInstanceOf('\DateTime', $result['created']);
-        $this->assertInstanceOf('\DateTime', $result['changed']);
 
         // content
         $this->assertEquals(array('title' => 'test'), $result['content']);

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/TimestampableSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/TimestampableSubscriber.php
@@ -1,0 +1,114 @@
+<?php
+/*
+ * This file is part of the Sulu CMF.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Persistence\EventSubscriber\ORM;
+
+use Doctrine\ORM\Events;
+use Doctrine\ORM\EntityManager;
+use Doctrine\Common\EventSubscriber;
+use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+use Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs;
+use Sulu\Component\Persistence\Model\TimestampableInterface;
+
+/**
+ * Manage the timestamp fields on models implementing the
+ * TimestampableInterface.
+ */
+class TimestampableSubscriber implements EventSubscriber
+{
+    const CREATED_FIELD = 'created';
+    const CHANGED_FIELD = 'changed';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getSubscribedEvents()
+    {
+        return array(
+            Events::loadClassMetadata,
+            Events::preUpdate,
+            Events::prePersist,
+        );
+    }
+
+    /**
+     * Load the class data, mapping the created and changed fields
+     * to datetime fields.
+     *
+     * @param LoadClassMetadataEventArgs $event
+     */
+    public function loadClassMetadata(LoadClassMetadataEventArgs $event)
+    {
+        $metadata = $event->getClassMetadata();
+        $reflection = $metadata->getReflectionClass();
+
+        if ($reflection->implementsInterface('Sulu\Component\Persistence\Model\TimestampableInterface')) {
+            if (!$metadata->hasField(self::CREATED_FIELD)) {
+                $metadata->mapField(array(
+                    'fieldName' => self::CREATED_FIELD,
+                    'type' => 'datetime',
+                    'notnull' => true,
+                ));
+            }
+
+            if (!$metadata->hasField(self::CHANGED_FIELD)) {
+                $metadata->mapField(array(
+                    'fieldName' => self::CHANGED_FIELD,
+                    'type' => 'datetime',
+                    'notnull' => true,
+                ));
+            }
+        }
+    }
+
+    /**
+     * Set the timestamps before update
+     *
+     * @param LifecycleEventArgs $events
+     */
+    public function preUpdate(LifecycleEventArgs $event)
+    {
+        $this->handleTimestamp($event);
+    }
+
+    /**
+     * Set the timestamps before creation
+     *
+     * @param LifecycleEventArgs $events
+     */
+    public function prePersist(LifecycleEventArgs $event)
+    {
+        $this->handleTimestamp($event);
+    }
+
+    /**
+     * Set the timestamps. If created is NULL then set it. Always
+     * set the changed field.
+     *
+     * @param LifecycleEventArgs $event
+     */
+    private function handleTimestamp(LifecycleEventArgs $event)
+    {
+        $entity = $event->getObject();
+
+        if (!$entity instanceof TimestampableInterface) {
+            return;
+        }
+
+        $meta = $event->getObjectManager()->getClassMetadata(get_class($entity));
+
+        $created = $meta->getFieldValue($entity, self::CREATED_FIELD);
+        if (null === $created) {
+            $meta->setFieldValue($entity, self::CREATED_FIELD, new \DateTime());
+        }
+
+        $meta->setFieldValue($entity, self::CHANGED_FIELD, new \DateTime());
+    }
+}

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
@@ -1,0 +1,215 @@
+<?php
+/*
+ * This file is part of the Sulu CMF.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Persistence\EventSubscriber\ORM;
+
+use Doctrine\ORM\Events;
+use Doctrine\ORM\EntityManager;
+use Doctrine\Common\EventSubscriber;
+use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+use Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs;
+use Sulu\Component\Persistence\Model\UserBlameInterface;
+use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Sulu\Component\Security\Authentication\UserInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+
+/**
+ * Ensure that blame can be assigned to users when they break things.
+ *
+ * Persists the user that created and the last user that changed ORM classes
+ * implementing UserBlameInterface.
+ */
+class UserBlameSubscriber implements EventSubscriber
+{
+    const CHANGER_FIELD = 'changer';
+    const CREATOR_FIELD = 'creator';
+
+    /**
+     * @var TokenStorage
+     */
+    private $tokenStorage;
+
+    /**
+     * @var object[]
+     */
+    private $blameQueue = array();
+
+    /**
+     * @param TokenStorage $tokenStorage
+     */
+    public function __construct(TokenStorage $tokenStorage = null)
+    {
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getSubscribedEvents()
+    {
+        $events = array(
+            Events::loadClassMetadata,
+            Events::onFlush,
+        );
+
+        return $events;
+    }
+
+    /**
+     * Map creator and changer fields to User objects
+     *
+     * @param LoadClassMetadataEventArgs $event
+     */
+    public function loadClassMetadata(LoadClassMetadataEventArgs $event)
+    {
+        $metadata = $event->getClassMetadata();
+        $reflection = $metadata->getReflectionClass();
+
+        if ($reflection->implementsInterface('Sulu\Component\Persistence\Model\UserBlameInterface')) {
+            if (!$metadata->hasAssociation(self::CREATOR_FIELD)) {
+                $metadata->mapManyToOne(array(
+                    'fieldName' => self::CREATOR_FIELD,
+                    'targetEntity' => UserInterface::class,
+                    'joinColumns' => array(
+                        array(
+                            'name' => 'idUsersCreator',
+                            'onDelete' => 'SET NULL',
+                            'referencedColumnName' => 'id',
+                            'nullable'=> true,
+                        ),
+                    ),
+                ));
+            }
+
+            if (!$metadata->hasAssociation(self::CHANGER_FIELD)) {
+                $metadata->mapManyToOne(array(
+                    'fieldName' => self::CHANGER_FIELD,
+                    'targetEntity' => UserInterface::class,
+                    'joinColumns' => array(
+                        array(
+                            'name' => 'idUsersChanger',
+                            'onDelete' => 'SET NULL',
+                            'referencedColumnName' => 'id',
+                            'nullable'=> true,
+                        ),
+                    ),
+                ));
+            }
+        }
+    }
+
+    public function onFlush(OnFlushEventArgs $event)
+    {
+        if (null === $this->tokenStorage) {
+            return;
+        }
+
+        $token = $this->tokenStorage->getToken();
+
+        // if no token, do nothing
+        if (null === $token) {
+            return;
+        }
+
+        $user = $this->getUser($token);
+        $manager = $event->getEntityManager();
+        $unitOfWork = $manager->getUnitOfWork();
+
+        $entities = array_merge(
+            $unitOfWork->getScheduledEntityInsertions(),
+            $unitOfWork->getScheduledEntityUpdates()
+        );
+
+        foreach ($entities as $blameEntity) {
+            if (!$blameEntity instanceof UserBlameInterface) {
+                continue;
+            }
+
+            $meta = $manager->getClassMetadata(get_class($blameEntity));
+
+            $changeset = $unitOfWork->getEntityChangeSet($blameEntity);
+            $recompute = false;
+
+            $creatorChangeset = isset($changeset[self::CREATOR_FIELD]) ? $changeset[self::CREATOR_FIELD] : null;
+            $changerChangeset = isset($changeset[self::CHANGER_FIELD]) ? $changeset[self::CHANGER_FIELD] : null;
+
+            if ($creatorChangeset) {
+                // if the creator is NULL and has not been set
+                if (null === $creatorChangeset[0] && null === $creatorChangeset[1]) {
+                    $meta->setFieldValue($blameEntity, self::CREATOR_FIELD, $user);
+                    $recompute = true;
+                }
+            }
+
+            if ($changerChangeset) {
+                // if the changer is NULL and has not been set or if the changer
+                // has not been explicitly set (i.e. both before and after changes
+                // are the same).
+                if (
+                    (null === $changerChangeset[0] && null === $changerChangeset[1]) ||
+                    ($changerChangeset[0] === $changerChangeset[1])
+                ) {
+                    $meta->setFieldValue($blameEntity, self::CHANGER_FIELD, $user);
+                    $recompute = true;
+                }
+            }
+
+            if (true === $recompute) {
+                $unitOfWork->recomputeSingleEntityChangeSet($meta, $blameEntity);
+            }
+        }
+
+        $this->blameQueue = array();
+    }
+
+    /**
+     * Record the creating and changing user on the
+     * entity based on the logged-in user.
+     *
+     * If the creator is null, then the creator will be
+     * set. The changer will always be overwritten.
+     *
+     * @param LifecycleEventArgs $event
+     */
+    private function handleUserBlame(LifecycleEventArgs $event)
+    {
+        $entity = $event->getObject();
+
+        if (!$entity instanceof UserBlameInterface) {
+            return;
+        }
+
+        $this->blameQueue[] = $entity;
+    }
+
+    /**
+     * Return the user from the token
+     *
+     * @param TokenInterface
+     *
+     * @return UserInterface
+     */
+    private function getUser(TokenInterface $token)
+    {
+        $user = $token->getUser();
+
+        if (!$user instanceof UserInterface) {
+            throw new \RuntimeException(sprintf(
+                'Expected user object to be an instance of (Sulu) UserInterface. Got "%s"',
+                is_object($user) ? get_class($user) : gettype($user)
+            ));
+        }
+
+        return $user;
+    }
+}

--- a/src/Sulu/Component/Persistence/Model/AuditableInterface.php
+++ b/src/Sulu/Component/Persistence/Model/AuditableInterface.php
@@ -1,0 +1,18 @@
+<?php
+/*
+ * This file is part of the Sulu CMF.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Persistence\Model;
+
+/**
+ * Composite interface of TimestampableInterface and UserBlameInterface
+ */
+interface AuditableInterface extends TimestampableInterface, UserBlameInterface
+{
+}

--- a/src/Sulu/Component/Persistence/Model/TimestampableInterface.php
+++ b/src/Sulu/Component/Persistence/Model/TimestampableInterface.php
@@ -1,0 +1,34 @@
+<?php
+/*
+ * This file is part of the Sulu CMF.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Persistence\Model;
+
+/**
+ * Classes implementing this interface must keep
+ * track of when they were created and updated
+ */
+interface TimestampableInterface
+{
+    /**
+     * Return the date the object implementing this inteface
+     * was created.
+     *
+     * @return \DateTime
+     */
+    public function getCreated();
+
+    /**
+     * Return the date the object implementing this inteface
+     * was changed
+     *
+     * @return \DateTime
+     */
+    public function getChanged();
+}

--- a/src/Sulu/Component/Persistence/Model/UserBlameInterface.php
+++ b/src/Sulu/Component/Persistence/Model/UserBlameInterface.php
@@ -1,0 +1,34 @@
+<?php
+/*
+ * This file is part of the Sulu CMF.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Persistence\Model;
+
+/**
+ * Classes implemting this interface must ensure they keep track
+ * of uses that create and update it.
+ */
+interface UserBlameInterface 
+{
+    /**
+     * Return the ID of the user that created this object
+     *
+     * @return \DateTime
+     */
+    public function getCreator();
+
+    /**
+     * Return the ID of the last user to change
+     * this object
+     *
+     * @return \DateTime
+     */
+    public function getChanger();
+}
+

--- a/src/Sulu/Component/Security/Authentication/RoleInterface.php
+++ b/src/Sulu/Component/Security/Authentication/RoleInterface.php
@@ -10,11 +10,13 @@
 
 namespace Sulu\Component\Security\Authentication;
 
+use Sulu\Component\Persistence\Model\AuditableInterface;
+
 /**
  * Defines the interface for a role
  * @package Sulu\Bundle\SecurityBundle\Entity
  */
-interface RoleInterface
+interface RoleInterface extends AuditableInterface
 {
     /**
      * Set name
@@ -47,27 +49,11 @@ interface RoleInterface
     public function getSystem();
 
     /**
-     * Set created
-     *
-     * @param \DateTime $created
-     * @return RoleInterface
-     */
-    public function setCreated($created);
-
-    /**
      * Get created
      *
      * @return \DateTime
      */
     public function getCreated();
-
-    /**
-     * Set changed
-     *
-     * @param \DateTime $changed
-     * @return RoleInterface
-     */
-    public function setChanged($changed);
 
     /**
      * Get changed

--- a/tests/Sulu/Component/Persistence/EventSubscriber/ORM/TimestampableSubscriberTest.php
+++ b/tests/Sulu/Component/Persistence/EventSubscriber/ORM/TimestampableSubscriberTest.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ * This file is part of the Sulu CMF.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Persistence\EventSubscriber\ORM;
+
+use Prophecy\PhpUnit\ProphecyTestCase;
+use Prophecy\Argument;
+
+class TimestampableTest extends ProphecyTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        $this->loadClassMetadataEvent = $this->prophesize('Doctrine\ORM\Event\LoadClassMetadataEventArgs');
+        $this->lifecycleEvent = $this->prophesize('Doctrine\ORM\Event\LifecycleEventArgs');
+        $this->timestampableObject = $this->prophesize('\stdClass')
+            ->willImplement('Sulu\Component\Persistence\Model\TimestampableInterface');
+        $this->classMetadata = $this->prophesize('Doctrine\ORM\Mapping\ClassMetadata');
+        $this->refl = $this->prophesize('\ReflectionClass');
+        $this->entityManager = $this->prophesize('Doctrine\ORM\EntityManager');
+
+        $this->subscriber = new TimestampableSubscriber();
+    }
+
+    public function testLoadClassMetadata()
+    {
+        $this->loadClassMetadataEvent->getClassMetadata()->willReturn($this->classMetadata->reveal());
+        $this->classMetadata->getReflectionClass()->willReturn($this->refl->reveal());
+        $this->refl->implementsInterface('Sulu\Component\Persistence\Model\TimestampableInterface')->willReturn(true);
+
+        $this->classMetadata->mapField(Argument::any())->shouldBeCalled();
+        $this->classMetadata->hasField('created')->willReturn(false);
+        $this->classMetadata->hasField('changed')->willReturn(false);
+
+        $this->subscriber->loadClassMetadata($this->loadClassMetadataEvent->reveal());
+    }
+
+    public function provideOnPreUpdate()
+    {
+        return array(
+            array(null),
+            array(new \DateTime('2015-01-01')),
+        );
+    }
+
+    /**
+     * @dataProvider provideOnPreUpdate
+     */
+    public function testOnPreUpdate($created)
+    {
+        $entity = $this->timestampableObject->reveal();
+        $this->lifecycleEvent->getObject()->willReturn($this->timestampableObject->reveal());
+        $this->lifecycleEvent->getObjectManager()->willReturn($this->entityManager->reveal());
+        $this->entityManager->getClassMetadata(get_class($entity))->willReturn($this->classMetadata);
+
+        $this->classMetadata->getFieldValue($entity, 'created')->willReturn($created);
+
+        if (null === $created) {
+            $this->classMetadata->setFieldValue(
+                $entity,
+                'created',
+                Argument::type('\DateTime')
+            )->shouldBeCalled();
+        } else {
+            $this->classMetadata->setFieldValue(Argument::any())->shouldNotBeCalled();
+        }
+
+        $this->classMetadata->setFieldValue(
+            $entity,
+            'changed',
+            Argument::type('\DateTime')
+        )->shouldBeCalled();
+
+        $this->subscriber->preUpdate($this->lifecycleEvent->reveal());
+    }
+}

--- a/tests/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriberIntegrationTest.php
+++ b/tests/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriberIntegrationTest.php
@@ -1,0 +1,61 @@
+<?php
+/*
+ * This file is part of the Sulu CMF.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Persistence\EventSubscriber\ORM;
+
+use Prophecy\PhpUnit\ProphecyTestCase;
+use Prophecy\Argument;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Bundle\SecurityBundle\Entity\User;
+use Sulu\Bundle\ContactBundle\Entity\Contact;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+
+class UserBlameTest extends SuluTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        $this->initOrm();
+    }
+
+    protected function initOrm()
+    {
+        $this->purgeDatabase();
+    }
+
+    public function testUserBlame()
+    {
+        $context = $this->getContainer()->get('security.context');
+        $token = new UsernamePasswordToken('test', 'test', 'test_provider', array());
+        $user = new User();
+        $user->setUsername('dantleech');
+        $user->setPassword('foo');
+        $user->setLocale('fr');
+        $user->setSalt('saltz');
+        $this->db('ORM')->getOm()->persist($user);
+        $this->db('ORM')->getOm()->flush();
+        $token->setUser($user);
+
+        $context->setToken($token);
+        $contact = new Contact();
+        $contact->setFirstName('Max');
+        $contact->setLastName('Mustermann');
+        $contact->setPosition('CEO');
+        $contact->setSalutation("Sehr geehrter Herr Dr Mustermann");
+        $this->db('ORM')->getOm()->persist($contact);
+        $this->db('ORM')->getOm()->flush();
+
+        $changer = $contact->getChanger();
+        $creator = $contact->getCreator();
+
+        $this->assertSame($changer, $user);
+        $this->assertSame($creator, $user);
+    }
+}

--- a/tests/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriberTest.php
+++ b/tests/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriberTest.php
@@ -1,0 +1,148 @@
+<?php
+/*
+ * This file is part of the Sulu CMF.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Persistence\EventSubscriber\ORM;
+
+use Prophecy\PhpUnit\ProphecyTestCase;
+use Prophecy\Argument;
+
+class UserBlameSubscriberTest extends ProphecyTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        $this->loadClassMetadataEvent = $this->prophesize('Doctrine\ORM\Event\LoadClassMetadataEventArgs');
+
+        $this->onFlushEvent = $this->prophesize('Doctrine\ORM\Event\OnFlushEventArgs');
+
+        $this->userBlameObject = $this->prophesize('\stdClass')
+            ->willImplement('Sulu\Component\Persistence\Model\UserBlameInterface');
+        $this->classMetadata = $this->prophesize('Doctrine\ORM\Mapping\ClassMetadata');
+        $this->refl = $this->prophesize('\ReflectionClass');
+        $this->entityManager = $this->prophesize('Doctrine\ORM\EntityManager');
+        $this->unitOfWork = $this->prophesize('Doctrine\ORM\UnitOfWork');
+        $this->user = $this->prophesize('Sulu\Component\Security\Authentication\UserInterface');
+        $this->token = $this->prophesize('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $this->tokenStorage = $this->prophesize('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage');
+
+        $this->subscriber = new UserBlameSubscriber($this->tokenStorage->reveal(), true);
+
+        $this->tokenStorage->getToken()->willReturn($this->token->reveal());
+        $this->token->getUser()->willReturn($this->user->reveal());
+        $this->onFlushEvent->getEntityManager()->willReturn($this->entityManager);
+        $this->entityManager->getUnitOfWork()->willReturn($this->unitOfWork->reveal());
+    }
+
+    public function testLoadClassMetadata()
+    {
+        $this->loadClassMetadataEvent->getClassMetadata()->willReturn($this->classMetadata->reveal());
+        $this->classMetadata->getReflectionClass()->willReturn($this->refl->reveal());
+        $this->refl->implementsInterface('Sulu\Component\Persistence\Model\UserBlameInterface')->willReturn(true);
+
+        $this->classMetadata->hasAssociation('creator')->shouldBeCalled();
+        $this->classMetadata->hasAssociation('changer')->shouldBeCalled();
+        $this->classMetadata->mapManyToOne(Argument::any())->shouldBeCalled();
+
+        $this->subscriber->loadClassMetadata($this->loadClassMetadataEvent->reveal());
+    }
+
+    public function provideLifecycle()
+    {
+        return array(
+            // changer not overridden, creator is not null
+            // RESULT: Only set changer
+            array(
+                array(
+                    'changer' => array(0 => 5, 1 => 5),
+                    'creator' => array(0 => 1, 1 => null),
+                ),
+                array(
+                    'changer',
+                ),
+            ),
+            // changer is null, creator is null
+            // RESULT: Set creator and changer
+            array(
+                array(
+                    'changer' => array(0 => null, 1 => null),
+                    'creator' => array(0 => null, 1 => null),
+                ),
+                array(
+                    'creator',
+                    'changer',
+                ),
+            ),
+            // changer has been overridden, creator is null
+            // RESULT: Set creator and changer
+            array(
+                array(
+                    'changer' => array(0 => null, 1 => 3),
+                    'creator' => array(0 => null, 1 => null),
+                ),
+                array(
+                    'creator',
+                ),
+            ),
+            // changer is has been changed, creator has been changed
+            // RESULT: Do not set anything
+            array(
+                array(
+                    'changer' => array(0 => 1, 1 => 2),
+                    'creator' => array(0 => 1, 1 => 2),
+                ),
+                array(
+                ),
+            ),
+        );
+    }
+
+    /**
+     * @param $changeset The changeset for the entity
+     * @param $expectedFields List of filds which should be updated/set
+     *
+     * @dataProvider provideLifecycle
+     */
+    public function testOnFlush($changeset, $expectedFields)
+    {
+        $entity = $this->userBlameObject->reveal();
+
+        $this->unitOfWork->getScheduledEntityInsertions()->willReturn(array(
+            $entity
+        ));
+        $this->unitOfWork->getScheduledEntityUpdates()->willReturn(array());
+
+        $this->entityManager->getClassMetadata(get_class($entity))->willReturn($this->classMetadata);
+        $this->unitOfWork->getEntityChangeSet($this->userBlameObject->reveal())->willReturn($changeset);
+
+        foreach (array('creator', 'changer') as $field) {
+            $prophecy = $this->classMetadata->setFieldValue(
+                $this->userBlameObject->reveal(),
+                $field,
+                $this->user->reveal()
+            );
+
+            if (in_array($field, $expectedFields)) {
+                $prophecy->shouldBeCalled();
+                continue;
+            }
+
+            $prophecy->shouldNotBeCalled();
+        }
+
+        if (count($expectedFields)) {
+            $this->unitOfWork->recomputeSingleEntityChangeSet(
+                $this->classMetadata->reveal(),
+                $this->userBlameObject->reveal()
+            )->shouldBeCalled();
+        }
+
+        $this->subscriber->onFlush($this->onFlushEvent->reveal());
+    }
+}


### PR DESCRIPTION
This PR adds 2 doctrine subscribers and three interfaces.

- `TimestampableInterface`: Entities implementing this interface will have their timestamps updated automatically and their mappings set. They must implement `getChanged` and `getCreated` (but not `setChanged|Created`)
- `UserBlameInterface`: Entities implementing this interface have their mappings set and optionally the user creator / changer updateted from the `security.context`. This is disabled by default.
- `AuditableInterface`: Implents both of the above.

Note that I have disabled the automatic updating of the `creator` and `changer` fields because there are extant API's which pass the `$user` directly.

We can either refactor them all now (and make this fully automatic) or ... not.