### PR TITLE
changed base collection properties to protected for inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * HOTFIX      #737 [MediaBundle]    Changed BaseCollection properties to be protected for inheritance
+
 * 0.14.0 (2015-01-15)
     * ENHANCEMENT #695 [ContentBundle]  Hide textblock sort option when there is only 1 textblock available
     * FEATURE     #634 [AdminBundle]    Created new configuration component, added new configuration for autocomplete

--- a/src/Sulu/Bundle/MediaBundle/Entity/BaseCollection.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/BaseCollection.php
@@ -20,57 +20,57 @@ abstract class BaseCollection implements CollectionInterface
     /**
      * @var string
      */
-    private $style;
+    protected $style;
 
     /**
      * @var integer
      * @Exclude
      */
-    private $lft;
+    protected $lft;
 
     /**
      * @var integer
      * @Exclude
      */
-    private $rgt;
+    protected $rgt;
 
     /**
      * @var integer
      * @Exclude
      */
-    private $depth;
+    protected $depth;
 
     /**
      * @var \DateTime
      */
-    private $created;
+    protected $created;
 
     /**
      * @var \DateTime
      */
-    private $changed;
+    protected $changed;
 
     /**
      * @var integer
      */
-    private $id;
+    protected $id;
 
     /**
      * @var \Sulu\Bundle\MediaBundle\Entity\CollectionType
      */
-    private $type;
+    protected $type;
 
     /**
      * @var \Sulu\Component\Security\UserInterface
      * @Exclude
      */
-    private $changer;
+    protected $changer;
 
     /**
      * @var \Sulu\Component\Security\UserInterface
      * @Exclude
      */
-    private $creator;
+    protected $creator;
 
     /**
      * Set changer


### PR DESCRIPTION
This PR sets the `BaseCollection`-properties to protected, because one of our servers didn't handle that correctly (although it works on a lot of machines). And it looks like what you should do, according to the [Doctrine documentation](http://doctrine-orm.readthedocs.org/en/latest/reference/inheritance-mapping.html)

__Tasks:__

- [x] test coverage
- [ ] gather feedback for my changes
- [x] added changelog line

__Informations:__

| Q             | A
| ------------- | ---
| Tests pass?   | yes
| Fixed tickets | none
| BC Breaks     | none
| Doc           | none