### PR TITLE
Hotfix avoid call move resourcelocator on none changed url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 CHANGELOG for Sulu
 ==================
+    * HOTFIX      #741 [ContentBundle]  Fix Resourcelocater Content Type call move without editing
 
 * 0.14.0 (2015-01-15)
     * ENHANCEMENT #695 [ContentBundle]  Hide textblock sort option when there is only 1 textblock available

--- a/src/Sulu/Component/Content/Types/ResourceLocator.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator.php
@@ -160,7 +160,7 @@ class ResourceLocator extends ComplexContentType implements ResourceLocatorInter
         // or the tree value does not exist
         if ($treeValue === null) {
             $this->getStrategy()->save($node, $value, $userId, $webspaceKey, $languageCode, $segmentKey);
-        } elseif ($propertyValue === $treeValue) {
+        } elseif ($propertyValue === $treeValue && $propertyValue != $value) {
             $this->getStrategy()->move(
                 $treeValue,
                 $value,


### PR DESCRIPTION
avoid url move in resource locator content type called when nothing changed

__Tasks:__

- [x] test coverage
- [ ] gather feedback for my changes
- [x] added changelog line

__Informations:__

| Q             | A
| ------------- | ---
| Tests pass?   | none
| Fixed tickets | #741
| BC Breaks     | no
| Doc           | none