### PR TITLE
Enahncement/renamed request analyzer methods

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -36,6 +36,12 @@ anything else. See the [HTTP cache
 documentation](http://sulu.readthedocs.org/en/latest/reference/bundles/http_cache.html)
 for more information.
 
+### Renamed RequestAnalyzerInterface methods
+
+The text "Current" has been removed from all of the request analyzer methods.
+If you used the request analyzer service then you will probably need to update
+your code, see: https://github.com/sulu-cmf/sulu/pull/749/files#diff-23
+
 ## 0.14.0
 
 * Role name is now unique

--- a/src/Sulu/Bundle/ContentBundle/Controller/NodeController.php
+++ b/src/Sulu/Bundle/ContentBundle/Controller/NodeController.php
@@ -576,7 +576,7 @@ class NodeController extends RestController implements ClassResourceInterface, S
     public function getSecurityContext()
     {
         $requestAnalyzer = $this->get('sulu_core.webspace.request_analyzer.admin');
-        $webspace = $requestAnalyzer->getCurrentWebspace();
+        $webspace = $requestAnalyzer->getWebspace();
 
         if ($webspace) {
             return 'sulu.webspaces.' . $webspace->getKey();

--- a/src/Sulu/Bundle/SearchBundle/EventListener/HitListener.php
+++ b/src/Sulu/Bundle/SearchBundle/EventListener/HitListener.php
@@ -42,7 +42,7 @@ class HitListener
         $document = $event->getHit()->getDocument();
         $url = sprintf(
             '%s/%s',
-            rtrim($this->requestAnalyzer->getCurrentResourceLocatorPrefix(), '/'),
+            rtrim($this->requestAnalyzer->getResourceLocatorPrefix(), '/'),
             ltrim($document->getUrl(), '/')
         );
         $document->setUrl($url);

--- a/src/Sulu/Bundle/SecurityBundle/Entity/UserRepository.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/UserRepository.php
@@ -247,11 +247,11 @@ class UserRepository extends EntityRepository implements UserRepositoryInterface
         $system = $this->suluSystem;
         if (
             $this->requestAnalyzer != null &&
-            $this->requestAnalyzer->getCurrentWebspace() !== null &&
-            $this->requestAnalyzer->getCurrentWebspace()->getSecurity() !== null
+            $this->requestAnalyzer->getWebspace() !== null &&
+            $this->requestAnalyzer->getWebspace()->getSecurity() !== null
         ) {
             // if the request analyzer is available, overwrite the system
-            $system = $this->requestAnalyzer->getCurrentWebspace()->getSecurity()->getSystem();
+            $system = $this->requestAnalyzer->getWebspace()->getSecurity()->getSystem();
         }
 
         return $system;

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Entity/UserRepositoryTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Entity/UserRepositoryTest.php
@@ -155,7 +155,7 @@ class UserRepositoryTest extends SuluTestCase
 //        $repo = $em->getRepository('Sulu\Bundle\SecurityBundle\Entity\User');
 //        $employees = $repo->getUserInSystem();
 //
-//        // FIXME alternative would be to get the container via the factory but there following in the repo is null $this->requestAnalyzer->getCurrentWebspace()
+//        // FIXME alternative would be to get the container via the factory but there following in the repo is null $this->requestAnalyzer->getWebspace()
 //        $repo = $client->getContainer()->get('sulu_security.user_repository_factory')->getRepository();
 //
 //        $this->assertEquals(1, count($employees));

--- a/src/Sulu/Bundle/SnippetBundle/Twig/SnippetTwigExtension.php
+++ b/src/Sulu/Bundle/SnippetBundle/Twig/SnippetTwigExtension.php
@@ -66,7 +66,7 @@ class SnippetTwigExtension extends \Twig_Extension implements SnippetTwigExtensi
             $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocalization();
         }
 
-        $snippet = $this->contentMapper->load($uuid, $this->requestAnalyzer->getCurrentWebspace()->getKey(), $locale);
+        $snippet = $this->contentMapper->load($uuid, $this->requestAnalyzer->getWebspace()->getKey(), $locale);
 
         return $this->structureResolver->resolve($snippet);
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/ExceptionController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/ExceptionController.php
@@ -53,14 +53,14 @@ class ExceptionController extends BaseExceptionController
                         'ClientWebsiteBundle:views:error404.html.twig',
                         array(
                             'request' => array(
-                                'webspaceKey' => $this->requestAnalyzer->getCurrentWebspace()->getKey(),
-                                'locale' => $this->requestAnalyzer->getCurrentLocalization()->getLocalization(),
-                                'portalUrl' => $this->requestAnalyzer->getCurrentPortalUrl(),
-                                'resourceLocatorPrefix' => $this->requestAnalyzer->getCurrentResourceLocatorPrefix(),
-                                'resourceLocator' => $this->requestAnalyzer->getCurrentResourceLocator(),
-                                'get' => $this->requestAnalyzer->getCurrentGetParameter(),
-                                'post' => $this->requestAnalyzer->getCurrentPostParameter(),
-                                'analyticsKey' => $this->requestAnalyzer->getCurrentAnalyticsKey(),
+                                'webspaceKey' => $this->requestAnalyzer->getWebspace()->getKey(),
+                                'locale' => $this->requestAnalyzer->getCurrentLocalization(),
+                                'portalUrl' => $this->requestAnalyzer->getPortalUrl(),
+                                'resourceLocatorPrefix' => $this->requestAnalyzer->getResourceLocatorPrefix(),
+                                'resourceLocator' => $this->requestAnalyzer->getResourceLocator(),
+                                'get' => $this->requestAnalyzer->getGetParameters(),
+                                'post' => $this->requestAnalyzer->getPostParameters()
+                                'analyticsKey' => $this->requestAnalyzer->getAnalyticsKey(),
                             ),
                             'path' => $request->getPathInfo()
                         )
@@ -80,7 +80,7 @@ class ExceptionController extends BaseExceptionController
                             'exception' => $exception,
                             'currentContent' => $currentContent,
                             'request' => array(
-                                'webspaceKey' => $this->requestAnalyzer->getCurrentWebspace()->getKey(),
+                                'webspaceKey' => $this->requestAnalyzer->getWebspace()->getKey(),
                                 'locale' => $this->requestAnalyzer->getCurrentLocalization()->getLocalization()
                             )
                         )

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/SitemapController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/SitemapController.php
@@ -31,8 +31,8 @@ class SitemapController extends WebsiteController
         /** @var SitemapGeneratorInterface $sitemapGenerator */
         $sitemapGenerator = $this->get('sulu_website.sitemap');
 
-        $webspace = $requestAnalyzer->getCurrentWebspace();
-        $currentPortal = $requestAnalyzer->getCurrentPortal();
+        $webspace = $requestAnalyzer->getWebspace();
+        $currentPortal = $requestAnalyzer->getPortal();
         $defaultLocale = null;
         if ($currentPortal !== null && ($defaultLocale = $currentPortal->getDefaultLocalization()) !== null) {
             $defaultLocale = $defaultLocale->getLocalization();
@@ -47,7 +47,7 @@ class SitemapController extends WebsiteController
         $response->headers->set('Content-Type', 'text/xml');
 
         $localizations = array();
-        foreach ($requestAnalyzer->getCurrentPortal()->getLocalizations() as $localization) {
+        foreach ($requestAnalyzer->getPortal()->getLocalizations() as $localization) {
             $localizations[] = $localization->getLocalization();
         }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
@@ -97,10 +97,10 @@ abstract class WebsiteController extends Controller
                 ->resolveForPreview($structure->getWebspaceKey(), $structure->getLanguageCode());
         }
 
-        if (null !== ($portal = $requestAnalyzer->getCurrentPortal())) {
+        if (null !== ($portal = $requestAnalyzer->getPortal())) {
             $allLocalizations = $portal->getLocalizations();
         } else {
-            $allLocalizations = $requestAnalyzer->getCurrentWebspace()->getLocalizations();
+            $allLocalizations = $requestAnalyzer->getWebspace()->getLocalizations();
         }
 
         $urls = array_key_exists('urls', $structureData) ? $structureData['urls'] : array();

--- a/src/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollector.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollector.php
@@ -34,13 +34,13 @@ class SuluCollector extends DataCollector
     {
         $requestAnalyzer = $this->requestAnalyzer;
 
-        $webspace = $requestAnalyzer->getCurrentWebspace();
-        $portal = $requestAnalyzer->getCurrentPortal();
-        $segment = $requestAnalyzer->getCurrentSegment();
+        $webspace = $requestAnalyzer->getWebspace();
+        $portal = $requestAnalyzer->getPortal();
+        $segment = $requestAnalyzer->getSegment();
 
-        $this->data['match_type'] = $requestAnalyzer->getCurrentMatchType();
-        $this->data['redirect'] = $requestAnalyzer->getCurrentRedirect();
-        $this->data['portal_url'] = $requestAnalyzer->getCurrentPortalUrl();
+        $this->data['match_type'] = $requestAnalyzer->getMatchType();
+        $this->data['redirect'] = $requestAnalyzer->getRedirect();
+        $this->data['portal_url'] = $requestAnalyzer->getPortalUrl();
 
         if ($webspace) {
             $this->data['webspace'] = $webspace->toArray();
@@ -55,8 +55,8 @@ class SuluCollector extends DataCollector
         }
 
         $this->data['localization'] = $requestAnalyzer->getCurrentLocalization();
-        $this->data['resource_locator'] = $requestAnalyzer->getCurrentResourceLocator();
-        $this->data['resource_locator_prefix'] = $requestAnalyzer->getCurrentResourceLocatorPrefix();
+        $this->data['resource_locator'] = $requestAnalyzer->getResourceLocator();
+        $this->data['resource_locator_prefix'] = $requestAnalyzer->getResourceLocatorPrefix();
 
         $structure = null;
         if ($request->attributes->has('_route_params')) {

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/SetThemeEventListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/SetThemeEventListener.php
@@ -48,7 +48,7 @@ class SetThemeEventListener
      */
     public function onKernelRequest(GetResponseEvent $event)
     {
-        $portal = $this->requestAnalyzer->getCurrentPortal();
+        $portal = $this->requestAnalyzer->getPortal();
 
         if (null === $portal) {
             return;

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolver.php
@@ -48,20 +48,20 @@ class RequestAnalyzerResolver implements RequestAnalyzerResolverInterface
     public function resolve(RequestAnalyzerInterface $requestAnalyzer)
     {
         // determine default locale (if one exists)
-        $defaultLocalization = $requestAnalyzer->getCurrentPortal()->getDefaultLocalization();
+        $defaultLocalization = $requestAnalyzer->getPortal()->getDefaultLocalization();
         $defaultLocale = $defaultLocalization ? $defaultLocalization->getLocalization() : null;
 
         return array(
             'request' => array(
-                'webspaceKey' => $requestAnalyzer->getCurrentWebspace()->getKey(),
+                'webspaceKey' => $requestAnalyzer->getWebspace()->getKey(),
                 'defaultLocale' => $defaultLocale,
                 'locale' => $requestAnalyzer->getCurrentLocalization()->getLocalization(),
-                'portalUrl' => $requestAnalyzer->getCurrentPortalUrl(),
-                'resourceLocatorPrefix' => $requestAnalyzer->getCurrentResourceLocatorPrefix(),
-                'resourceLocator' => $requestAnalyzer->getCurrentResourceLocator(),
-                'get' => $requestAnalyzer->getCurrentGetParameter(),
-                'post' => $requestAnalyzer->getCurrentPostParameter(),
-                'analyticsKey' => $requestAnalyzer->getCurrentAnalyticsKey(),
+                'portalUrl' => $requestAnalyzer->getPortalUrl(),
+                'resourceLocatorPrefix' => $requestAnalyzer->getResourceLocatorPrefix(),
+                'resourceLocator' => $requestAnalyzer->getResourceLocator(),
+                'get' => $requestAnalyzer->getGetParameters(),
+                'post' => $requestAnalyzer->getPostParameters(),
+                'analyticsKey' => $requestAnalyzer->getAnalyticsKey(),
             )
         );
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
@@ -62,17 +62,17 @@ class ContentRouteProvider implements RouteProviderInterface
         $collection = new RouteCollection();
 
         $htmlExtension = '.html';
-        $resourceLocator = $this->requestAnalyzer->getCurrentResourceLocator();
+        $resourceLocator = $this->requestAnalyzer->getResourceLocator();
 
-        if ($this->requestAnalyzer->getCurrentMatchType() == RequestAnalyzerInterface::MATCH_TYPE_REDIRECT
-            || $this->requestAnalyzer->getCurrentMatchType() == RequestAnalyzerInterface::MATCH_TYPE_PARTIAL
+        if ($this->requestAnalyzer->getMatchType() == RequestAnalyzerInterface::MATCH_TYPE_REDIRECT
+            || $this->requestAnalyzer->getMatchType() == RequestAnalyzerInterface::MATCH_TYPE_PARTIAL
         ) {
             // redirect by information from webspace config
             $route = new Route(
                 $request->getRequestUri(), array(
                     '_controller' => 'SuluWebsiteBundle:Default:redirectWebspace',
-                    'url' => $this->requestAnalyzer->getCurrentPortalUrl(),
-                    'redirect' => $this->requestAnalyzer->getCurrentRedirect()
+                    'url' => $this->requestAnalyzer->getPortalUrl(),
+                    'redirect' => $this->requestAnalyzer->getRedirect()
                 )
             );
 
@@ -82,7 +82,7 @@ class ContentRouteProvider implements RouteProviderInterface
             substr($request->getPathInfo(), -strlen($htmlExtension)) === $htmlExtension
         ) {
             $url = rtrim(
-                $this->requestAnalyzer->getCurrentResourceLocatorPrefix() . ($resourceLocator ? $resourceLocator : '/'),
+                $this->requestAnalyzer->getResourceLocatorPrefix() . ($resourceLocator ? $resourceLocator : '/'),
                 '/'
             );
 
@@ -97,7 +97,7 @@ class ContentRouteProvider implements RouteProviderInterface
             $collection->add('redirect_' . uniqid(), $route);
         } else {
             // just show the page
-            $portal = $this->requestAnalyzer->getCurrentPortal();
+            $portal = $this->requestAnalyzer->getPortal();
             $language = $this->requestAnalyzer->getCurrentLocalization()->getLocalization();
 
             try {
@@ -115,7 +115,7 @@ class ContentRouteProvider implements RouteProviderInterface
                     $route = new Route(
                         $request->getRequestUri(), array(
                             '_controller' => 'SuluWebsiteBundle:Default:redirect',
-                            'url' => $this->requestAnalyzer->getCurrentResourceLocatorPrefix() . $content->getResourceLocator()
+                            'url' => $this->requestAnalyzer->getResourceLocatorPrefix() . $content->getResourceLocator()
                         )
                     );
 
@@ -139,7 +139,7 @@ class ContentRouteProvider implements RouteProviderInterface
             } catch (ResourceLocatorNotFoundException $exc) {
                 // just do not add any routes to the collection
             } catch (ResourceLocatorMovedException $exc) {
-                $newUrl = $this->requestAnalyzer->getCurrentResourceLocatorPrefix() . $exc->getNewResourceLocator();
+                $newUrl = $this->requestAnalyzer->getResourceLocatorPrefix() . $exc->getNewResourceLocator();
 
                 // redirect to new url
                 $route = new Route(
@@ -208,7 +208,7 @@ class ContentRouteProvider implements RouteProviderInterface
      */
     private function checkResourceLocator()
     {
-        return !($this->requestAnalyzer->getCurrentResourceLocator() === '/'
-            && $this->requestAnalyzer->getCurrentResourceLocatorPrefix());
+        return !($this->requestAnalyzer->getResourceLocator() === '/'
+            && $this->requestAnalyzer->getResourceLocatorPrefix());
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollectorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollectorTest.php
@@ -33,16 +33,16 @@ class SuluCollectorTest extends ProphecyTestCase
 
     public function testCollector()
     {
-        $this->requestAnalyzer->getCurrentPortal()->willReturn($this->portal);
-        $this->requestAnalyzer->getCurrentWebspace()->willReturn($this->webspace);
-        $this->requestAnalyzer->getCurrentSegment()->willReturn($this->segment);
-        $this->requestAnalyzer->getCurrentMatchType()->willReturn('match');
-        $this->requestAnalyzer->getCurrentRedirect()->willReturn('red');
-        $this->requestAnalyzer->getCurrentPortalUrl()->willReturn('/foo');
+        $this->requestAnalyzer->getPortal()->willReturn($this->portal);
+        $this->requestAnalyzer->getWebspace()->willReturn($this->webspace);
+        $this->requestAnalyzer->getSegment()->willReturn($this->segment);
+        $this->requestAnalyzer->getMatchType()->willReturn('match');
+        $this->requestAnalyzer->getRedirect()->willReturn('red');
+        $this->requestAnalyzer->getPortalUrl()->willReturn('/foo');
 
         $this->requestAnalyzer->getCurrentLocalization()->willReturn('de_de');
-        $this->requestAnalyzer->getCurrentResourceLocator()->willReturn('/asd');
-        $this->requestAnalyzer->getCurrentResourceLocatorPrefix()->willReturn('/asd/');
+        $this->requestAnalyzer->getResourceLocator()->willReturn('/asd');
+        $this->requestAnalyzer->getResourceLocatorPrefix()->willReturn('/asd/');
         $this->request->attributes->set('_route_params', array('structure' => $this->structure->reveal()));
 
         $this->dataCollector->collect($this->request, $this->response->reveal());

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/EventListener/SetThemeEventListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/EventListener/SetThemeEventListenerTest.php
@@ -27,7 +27,7 @@ class SetThemeEventListenerTest extends \PHPUnit_Framework_TestCase
     public function testEventListener()
     {
         $this->requestAnalyzer->expects($this->once())
-            ->method('getCurrentPortal')
+            ->method('getPortal')
             ->will($this->returnValue($this->portal));
         $this->portal->expects($this->once())
             ->method('getWebspace')
@@ -48,7 +48,7 @@ class SetThemeEventListenerTest extends \PHPUnit_Framework_TestCase
     public function testEventListenerNotMaster()
     {
         $this->requestAnalyzer->expects($this->once())
-            ->method('getCurrentPortal')
+            ->method('getPortal')
             ->willReturn(null);
         $this->webspace->expects($this->never())
             ->method('getTheme');

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolverTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolverTest.php
@@ -89,15 +89,15 @@ class RequestAnalyzerResolverTest extends ProphecyTestCase
         $localization->setCountry('at');
 
         $requestAnalyzer = $this->prophesize('Sulu\Component\Webspace\Analyzer\WebsiteRequestAnalyzer');
-        $requestAnalyzer->getCurrentWebspace()->willReturn($webspace);
+        $requestAnalyzer->getWebspace()->willReturn($webspace);
         $requestAnalyzer->getCurrentLocalization()->willReturn($localization);
-        $requestAnalyzer->getCurrentPortalUrl()->willReturn('sulu.io/de');
-        $requestAnalyzer->getCurrentResourceLocatorPrefix()->willReturn('/de');
-        $requestAnalyzer->getCurrentResourceLocator()->willReturn('/search');
-        $requestAnalyzer->getCurrentGetParameter()->willReturn(array('p' => 1));
-        $requestAnalyzer->getCurrentPostParameter()->willReturn(array());
-        $requestAnalyzer->getCurrentPortal()->willReturn($portal);
-        $requestAnalyzer->getCurrentAnalyticsKey()->willReturn('analyticsKey');
+        $requestAnalyzer->getPortalUrl()->willReturn('sulu.io/de');
+        $requestAnalyzer->getResourceLocatorPrefix()->willReturn('/de');
+        $requestAnalyzer->getResourceLocator()->willReturn('/search');
+        $requestAnalyzer->getGetParameters()->willReturn(array('p' => 1));
+        $requestAnalyzer->getPostParameters()->willReturn(array());
+        $requestAnalyzer->getPortal()->willReturn($portal);
+        $requestAnalyzer->getAnalyticsKey()->willReturn('analyticsKey');
 
         $result = $this->resolver->resolve($requestAnalyzer->reveal());
         $this->assertEquals(

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProviderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProviderTest.php
@@ -448,13 +448,13 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
     )
     {
         $methods = array(
-            'getCurrentPortal',
+            'getPortal',
             'getCurrentPath',
-            'getCurrentRedirect',
-            'getCurrentPortalUrl',
-            'getCurrentMatchType',
-            'getCurrentResourceLocator',
-            'getCurrentResourceLocatorPrefix'
+            'getRedirect',
+            'getPortalUrl',
+            'getMatchType',
+            'getResourceLocator',
+            'getResourceLocatorPrefix'
         );
 
         if ($language != null) {
@@ -471,15 +471,15 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             $methods
         );
 
-        $portalManager->expects($this->any())->method('getCurrentPortal')->will($this->returnValue($portal));
+        $portalManager->expects($this->any())->method('getPortal')->will($this->returnValue($portal));
         $portalManager->expects($this->any())->method('getCurrentLocalization')->will($this->returnValue($language));
-        $portalManager->expects($this->any())->method('getCurrentRedirect')->will($this->returnValue($redirect));
-        $portalManager->expects($this->any())->method('getCurrentPortalUrl')->will($this->returnValue($url));
-        $portalManager->expects($this->any())->method('getCurrentMatchType')->will($this->returnValue($matchType));
-        $portalManager->expects($this->any())->method('getCurrentResourceLocator')->will(
+        $portalManager->expects($this->any())->method('getRedirect')->will($this->returnValue($redirect));
+        $portalManager->expects($this->any())->method('getPortalUrl')->will($this->returnValue($url));
+        $portalManager->expects($this->any())->method('getMatchType')->will($this->returnValue($matchType));
+        $portalManager->expects($this->any())->method('getResourceLocator')->will(
             $this->returnValue($resourceLocator)
         );
-        $portalManager->expects($this->any())->method('getCurrentResourceLocatorPrefix')->will(
+        $portalManager->expects($this->any())->method('getResourceLocatorPrefix')->will(
             $this->returnValue($resourceLocatorPrefix)
         );
 
@@ -521,7 +521,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
     {
         $request = $this->getMock('\Symfony\Component\HttpFoundation\Request', array('getRequestUri'));
         $request->expects($this->any())->method('getRequestUri')->will($this->returnValue($path));
-        $request->expects($this->any())->method('getCurrentResourceLocatorPrefix')->will($this->returnValue($prefix));
+        $request->expects($this->any())->method('getResourceLocatorPrefix')->will($this->returnValue($prefix));
 
         return $request;
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentTwigExtensionTest.php
@@ -117,7 +117,7 @@ class ContentTwigExtensionTest extends ProphecyTestCase
         $locale->setCountry('us');
         $locale->setLanguage('en');
 
-        $this->requestAnalyzer->getCurrentWebspace()->willReturn($webspace);
+        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
         $this->requestAnalyzer->getCurrentLocalization()->willReturn($locale);
 
         $this->contentTypeManager->get('text_line')->willReturn(new TextLine(''));

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentPathTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentPathTwigExtension.php
@@ -82,7 +82,7 @@ class ContentPathTwigExtension extends \Twig_Extension implements ContentPathInt
                 return rtrim($portalUrls[0], '/');
             }
         } elseif (strpos($url, '/') === 0 && $this->requestAnalyzer) {
-            return rtrim($this->requestAnalyzer->getCurrentResourceLocatorPrefix() . $url, '/');
+            return rtrim($this->requestAnalyzer->getResourceLocatorPrefix() . $url, '/');
         }
 
         return $url;
@@ -95,9 +95,9 @@ class ContentPathTwigExtension extends \Twig_Extension implements ContentPathInt
     {
         if ($this->requestAnalyzer !== null) {
             if ($full) {
-                return $this->requestAnalyzer->getCurrentPortalUrl();
+                return $this->requestAnalyzer->getPortalUrl();
             } else {
-                return $this->requestAnalyzer->getCurrentResourceLocatorPrefix();
+                return $this->requestAnalyzer->getResourceLocatorPrefix();
             }
         } else {
             return '/';

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
@@ -74,7 +74,7 @@ class ContentTwigExtension extends \Twig_Extension implements ContentTwigExtensi
     {
         $contentStructure = $this->contentMapper->load(
             $uuid,
-            $this->requestAnalyzer->getCurrentWebspace()->getKey(),
+            $this->requestAnalyzer->getWebspace()->getKey(),
             $this->requestAnalyzer->getCurrentLocalization()->getLocalization()
         );
 
@@ -87,7 +87,7 @@ class ContentTwigExtension extends \Twig_Extension implements ContentTwigExtensi
     public function loadParent($uuid)
     {
         $session = $this->sessionManager->getSession();
-        $contentsNode = $this->sessionManager->getContentNode($this->requestAnalyzer->getCurrentWebspace()->getKey());
+        $contentsNode = $this->sessionManager->getContentNode($this->requestAnalyzer->getWebspace()->getKey());
         $node = $session->getNodeByIdentifier($uuid);
 
         if ($node->getDepth() <= $contentsNode->getDepth()) {

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Meta/MetaTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Meta/MetaTwigExtension.php
@@ -64,9 +64,9 @@ class MetaTwigExtension extends \Twig_Extension
     public function getAlternateLinks($urls)
     {
         // determine default and current values
-        $webspaceKey = $this->requestAnalyzer->getCurrentWebspace()->getKey();
+        $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
         $currentLocale = $this->requestAnalyzer->getCurrentLocalization()->getLocalization();
-        $currentPortal = $this->requestAnalyzer->getCurrentPortal();
+        $currentPortal = $this->requestAnalyzer->getPortal();
         $defaultLocale = null;
         if ($currentPortal !== null && ($defaultLocale = $currentPortal->getDefaultLocalization()) !== null) {
             $defaultLocale = $defaultLocale->getLocalization();

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtension.php
@@ -66,7 +66,7 @@ class NavigationTwigExtension extends \Twig_Extension implements NavigationTwigE
      */
     public function flatRootNavigationFunction($context = null, $depth = 1, $loadExcerpt = false)
     {
-        $webspaceKey = $this->requestAnalyzer->getCurrentWebspace()->getKey();
+        $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
         $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocalization();
 
         return $this->navigationMapper->getRootNavigation($webspaceKey, $locale, $depth, true, $context, $loadExcerpt);
@@ -77,7 +77,7 @@ class NavigationTwigExtension extends \Twig_Extension implements NavigationTwigE
      */
     public function treeRootNavigationFunction($context = null, $depth = 1, $loadExcerpt = false)
     {
-        $webspaceKey = $this->requestAnalyzer->getCurrentWebspace()->getKey();
+        $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
         $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocalization();
 
         return $this->navigationMapper->getRootNavigation($webspaceKey, $locale, $depth, false, $context, $loadExcerpt);
@@ -88,7 +88,7 @@ class NavigationTwigExtension extends \Twig_Extension implements NavigationTwigE
      */
     public function flatNavigationFunction($uuid, $context = null, $depth = 1, $loadExcerpt = false, $level = null)
     {
-        $webspaceKey = $this->requestAnalyzer->getCurrentWebspace()->getKey();
+        $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
         $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocalization();
 
         if ($level !== null) {
@@ -114,7 +114,7 @@ class NavigationTwigExtension extends \Twig_Extension implements NavigationTwigE
      */
     public function treeNavigationFunction($uuid, $context = null, $depth = 1, $loadExcerpt = false, $level = null)
     {
-        $webspaceKey = $this->requestAnalyzer->getCurrentWebspace()->getKey();
+        $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
         $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocalization();
 
         if ($level !== null) {
@@ -140,7 +140,7 @@ class NavigationTwigExtension extends \Twig_Extension implements NavigationTwigE
      */
     public function breadcrumbFunction($uuid)
     {
-        $webspaceKey = $this->requestAnalyzer->getCurrentWebspace()->getKey();
+        $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
         $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocalization();
 
         return $this->navigationMapper->getBreadcrumb(

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/SitemapTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/SitemapTwigExtension.php
@@ -68,7 +68,7 @@ class SitemapTwigExtension extends \Twig_Extension implements SitemapTwigExtensi
     public function sitemapUrlFunction($url, $locale = null, $webspaceKey = null)
     {
         if ($webspaceKey === null) {
-            $webspaceKey = $this->requestAnalyzer->getCurrentWebspace()->getKey();
+            $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
         }
 
         if ($locale === null) {
@@ -96,7 +96,7 @@ class SitemapTwigExtension extends \Twig_Extension implements SitemapTwigExtensi
     public function sitemapFunction($locale = null, $webspaceKey = null)
     {
         if ($webspaceKey === null) {
-            $webspaceKey = $this->requestAnalyzer->getCurrentWebspace()->getKey();
+            $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
         }
 
         if ($locale === null) {

--- a/src/Sulu/Component/Webspace/Analyzer/AdminRequestAnalyzer.php
+++ b/src/Sulu/Component/Webspace/Analyzer/AdminRequestAnalyzer.php
@@ -89,7 +89,7 @@ class AdminRequestAnalyzer implements RequestAnalyzerInterface
         $this->localization = $this->webspace->getLocalization($locale);
     }
 
-    public function getCurrentMatchType()
+    public function getMatchType()
     {
         return null;
     }
@@ -98,7 +98,7 @@ class AdminRequestAnalyzer implements RequestAnalyzerInterface
      * Returns the current webspace for this request
      * @return Webspace
      */
-    public function getCurrentWebspace()
+    public function getWebspace()
     {
         return $this->webspace;
     }
@@ -107,7 +107,7 @@ class AdminRequestAnalyzer implements RequestAnalyzerInterface
      * Returns the current portal for this request
      * @return Portal
      */
-    public function getCurrentPortal()
+    public function getPortal()
     {
         return null;
     }
@@ -116,7 +116,7 @@ class AdminRequestAnalyzer implements RequestAnalyzerInterface
      * Returns the current segment for this request
      * @return Segment
      */
-    public function getCurrentSegment()
+    public function getSegment()
     {
         return null;
     }
@@ -134,7 +134,7 @@ class AdminRequestAnalyzer implements RequestAnalyzerInterface
      * Returns the url of the current Portal
      * @return string
      */
-    public function getCurrentPortalUrl()
+    public function getPortalUrl()
     {
         return null;
     }
@@ -143,7 +143,7 @@ class AdminRequestAnalyzer implements RequestAnalyzerInterface
      * Returns the redirect, null if there is no redirect
      * @return string
      */
-    public function getCurrentRedirect()
+    public function getRedirect()
     {
         return null;
     }
@@ -152,7 +152,7 @@ class AdminRequestAnalyzer implements RequestAnalyzerInterface
      * Returns the path of the current request, which is the url without host, language and so on
      * @return string
      */
-    public function getCurrentResourceLocator()
+    public function getResourceLocator()
     {
         return null;
     }
@@ -161,7 +161,7 @@ class AdminRequestAnalyzer implements RequestAnalyzerInterface
      * Returns the prefix required before the resource locator
      * @return string
      */
-    public function getCurrentResourceLocatorPrefix()
+    public function getResourceLocatorPrefix()
     {
         return null;
     }
@@ -170,7 +170,7 @@ class AdminRequestAnalyzer implements RequestAnalyzerInterface
      * Returns the post parameters
      * @return array
      */
-    public function getCurrentPostParameter()
+    public function getPostParameters()
     {
         return null;
     }
@@ -179,7 +179,7 @@ class AdminRequestAnalyzer implements RequestAnalyzerInterface
      * Returns the get parameters
      * @return array
      */
-    public function getCurrentGetParameter()
+    public function getGetParameters()
     {
         return null;
     }
@@ -188,7 +188,7 @@ class AdminRequestAnalyzer implements RequestAnalyzerInterface
      * Returns the analytics key
      * @return string
      */
-    public function getCurrentAnalyticsKey()
+    public function getAnalyticsKey()
     {
         return '';
     }

--- a/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzerInterface.php
+++ b/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzerInterface.php
@@ -55,25 +55,25 @@ interface RequestAnalyzerInterface
      * Returns the current match type for this request
      * @return int
      */
-    public function getCurrentMatchType();
+    public function getMatchType();
 
     /**
      * Returns the current webspace for this request
      * @return Webspace
      */
-    public function getCurrentWebspace();
+    public function getWebspace();
 
     /**
      * Returns the current portal for this request
      * @return Portal
      */
-    public function getCurrentPortal();
+    public function getPortal();
 
     /**
      * Returns the current segment for this request
      * @return Segment
      */
-    public function getCurrentSegment();
+    public function getSegment();
 
     /**
      * Returns the current localization for this Request
@@ -85,42 +85,42 @@ interface RequestAnalyzerInterface
      * Returns the redirect url
      * @return string
      */
-    public function getCurrentRedirect();
+    public function getRedirect();
 
     /**
      * Returns the url of the current portal
      * @return string
      */
-    public function getCurrentPortalUrl();
+    public function getPortalUrl();
 
     /**
      * Returns the path of the current request, which is the url without host, language and so on
      * @return string
      */
-    public function getCurrentResourceLocator();
+    public function getResourceLocator();
 
     /**
      * Returns the prefix required before the resource locator
      * @return string
      */
-    public function getCurrentResourceLocatorPrefix();
+    public function getResourceLocatorPrefix();
 
     /**
      * Returns the post parameters
      * @return array
      */
-    public function getCurrentPostParameter();
+    public function getPostParameters();
 
     /**
      * Returns the get parameters
      * @return array
      */
-    public function getCurrentGetParameter();
+    public function getGetParameters();
 
 
     /**
      * Returns the analytics key
      * @return string
      */
-    public function getCurrentAnalyticsKey();
+    public function getAnalyticsKey();
 }

--- a/src/Sulu/Component/Webspace/Analyzer/WebsiteRequestAnalyzer.php
+++ b/src/Sulu/Component/Webspace/Analyzer/WebsiteRequestAnalyzer.php
@@ -171,7 +171,7 @@ class WebsiteRequestAnalyzer implements RequestAnalyzerInterface
         );
     }
 
-    public function getCurrentMatchType()
+    public function getMatchType()
     {
         return $this->matchType;
     }
@@ -180,7 +180,7 @@ class WebsiteRequestAnalyzer implements RequestAnalyzerInterface
      * Returns the current webspace for this request
      * @return Webspace
      */
-    public function getCurrentWebspace()
+    public function getWebspace()
     {
         return $this->webspace;
     }
@@ -189,7 +189,7 @@ class WebsiteRequestAnalyzer implements RequestAnalyzerInterface
      * Returns the current portal for this request
      * @return Portal
      */
-    public function getCurrentPortal()
+    public function getPortal()
     {
         return $this->portal;
     }
@@ -198,7 +198,7 @@ class WebsiteRequestAnalyzer implements RequestAnalyzerInterface
      * Returns the current segment for this request
      * @return Segment
      */
-    public function getCurrentSegment()
+    public function getSegment()
     {
         return $this->segment;
     }
@@ -216,7 +216,7 @@ class WebsiteRequestAnalyzer implements RequestAnalyzerInterface
      * Returns the url of the current Portal
      * @return string
      */
-    public function getCurrentPortalUrl()
+    public function getPortalUrl()
     {
         return $this->portalUrl;
     }
@@ -225,7 +225,7 @@ class WebsiteRequestAnalyzer implements RequestAnalyzerInterface
      * Returns the redirect, null if there is no redirect
      * @return string
      */
-    public function getCurrentRedirect()
+    public function getRedirect()
     {
         return $this->redirect;
     }
@@ -234,7 +234,7 @@ class WebsiteRequestAnalyzer implements RequestAnalyzerInterface
      * Returns the path of the current request, which is the url without host, language and so on
      * @return string
      */
-    public function getCurrentResourceLocator()
+    public function getResourceLocator()
     {
         return $this->resourceLocator;
     }
@@ -243,7 +243,7 @@ class WebsiteRequestAnalyzer implements RequestAnalyzerInterface
      * Returns the prefix required before the resource locator
      * @return string
      */
-    public function getCurrentResourceLocatorPrefix()
+    public function getResourceLocatorPrefix()
     {
         return $this->resourceLocatorPrefix;
     }
@@ -252,7 +252,7 @@ class WebsiteRequestAnalyzer implements RequestAnalyzerInterface
      * Returns the post parameters
      * @return array
      */
-    public function getCurrentPostParameter()
+    public function getPostParameters()
     {
         return $this->postParameter;
     }
@@ -261,7 +261,7 @@ class WebsiteRequestAnalyzer implements RequestAnalyzerInterface
      * Returns the get parameters
      * @return array
      */
-    public function getCurrentGetParameter()
+    public function getGetParameters()
     {
         return $this->getParameter;
     }
@@ -379,7 +379,7 @@ class WebsiteRequestAnalyzer implements RequestAnalyzerInterface
      * Returns the analytics key
      * @return string
      */
-    public function getCurrentAnalyticsKey()
+    public function getAnalyticsKey()
     {
         return $this->analyticsKey;
     }

--- a/tests/Sulu/Component/Webspace/Analyzer/RequestAnalyzerTest.php
+++ b/tests/Sulu/Component/Webspace/Analyzer/RequestAnalyzerTest.php
@@ -190,15 +190,15 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
         $this->requestAnalyzer->analyze($request);
 
         $this->assertEquals('de_at', $this->requestAnalyzer->getCurrentLocalization()->getLocalization());
-        $this->assertEquals('sulu', $this->requestAnalyzer->getCurrentWebspace()->getKey());
-        $this->assertEquals('sulu', $this->requestAnalyzer->getCurrentPortal()->getKey());
-        $this->assertEquals(null, $this->requestAnalyzer->getCurrentSegment());
-        $this->assertEquals($expected['portal_url'], $this->requestAnalyzer->getCurrentPortalUrl());
-        $this->assertEquals($expected['redirect'], $this->requestAnalyzer->getCurrentRedirect());
-        $this->assertEquals($expected['resource_locator'], $this->requestAnalyzer->getCurrentResourceLocator());
-        $this->assertEquals($expected['resource_locator_prefix'], $this->requestAnalyzer->getCurrentResourceLocatorPrefix());
-        $this->assertEquals(array('post' => 1), $this->requestAnalyzer->getCurrentPostParameter());
-        $this->assertEquals(array('get' => 1), $this->requestAnalyzer->getCurrentGetParameter());
+        $this->assertEquals('sulu', $this->requestAnalyzer->getWebspace()->getKey());
+        $this->assertEquals('sulu', $this->requestAnalyzer->getPortal()->getKey());
+        $this->assertEquals(null, $this->requestAnalyzer->getSegment());
+        $this->assertEquals($expected['portal_url'], $this->requestAnalyzer->getPortalUrl());
+        $this->assertEquals($expected['redirect'], $this->requestAnalyzer->getRedirect());
+        $this->assertEquals($expected['resource_locator'], $this->requestAnalyzer->getResourceLocator());
+        $this->assertEquals($expected['resource_locator_prefix'], $this->requestAnalyzer->getResourceLocatorPrefix());
+        $this->assertEquals(array('post' => 1), $this->requestAnalyzer->getPostParameters());
+        $this->assertEquals(array('get' => 1), $this->requestAnalyzer->getGetParameters());
     }
 
     /**
@@ -258,19 +258,19 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
         $this->requestAnalyzer->analyze($request);
 
         $this->assertEquals('de_at', $this->requestAnalyzer->getCurrentLocalization()->getLocalization());
-        $this->assertEquals('sulu', $this->requestAnalyzer->getCurrentWebspace()->getKey());
-        $this->assertEquals('sulu', $this->requestAnalyzer->getCurrentPortal()->getKey());
-        $this->assertEquals(null, $this->requestAnalyzer->getCurrentSegment());
-        $this->assertEquals($expected['portal_url'], $this->requestAnalyzer->getCurrentPortalUrl());
-        $this->assertEquals($expected['redirect'], $this->requestAnalyzer->getCurrentRedirect());
-        $this->assertEquals($expected['resource_locator'], $this->requestAnalyzer->getCurrentResourceLocator());
+        $this->assertEquals('sulu', $this->requestAnalyzer->getWebspace()->getKey());
+        $this->assertEquals('sulu', $this->requestAnalyzer->getPortal()->getKey());
+        $this->assertEquals(null, $this->requestAnalyzer->getSegment());
+        $this->assertEquals($expected['portal_url'], $this->requestAnalyzer->getPortalUrl());
+        $this->assertEquals($expected['redirect'], $this->requestAnalyzer->getRedirect());
+        $this->assertEquals($expected['resource_locator'], $this->requestAnalyzer->getResourceLocator());
         $this->assertEquals(
             $expected['resource_locator_prefix'],
-            $this->requestAnalyzer->getCurrentResourceLocatorPrefix()
+            $this->requestAnalyzer->getResourceLocatorPrefix()
         );
         $this->assertEquals($expected['format'], $request->getRequestFormat());
-        $this->assertEquals(array('post' => 1), $this->requestAnalyzer->getCurrentPostParameter());
-        $this->assertEquals(array('get' => 1), $this->requestAnalyzer->getCurrentGetParameter());
+        $this->assertEquals(array('post' => 1), $this->requestAnalyzer->getPostParameters());
+        $this->assertEquals(array('get' => 1), $this->requestAnalyzer->getGetParameters());
     }
 
     /**


### PR DESCRIPTION
This PR renames all of the methods in the RequestAnalyzerInterface which begin with `getCurrent`.

Fixes #170 