### PR TITLE
Throw exception if command does not find any roles.

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Command/CreateUserCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/CreateUserCommand.php
@@ -241,6 +241,12 @@ class CreateUserCommand extends ContainerAwareCommand
                 $roles[] = $roleEntity['name'];
             }
 
+            if (! count($roles)) {
+                throw new \InvalidArgumentException(
+                    'Did not find any roles. Have you created any?'
+                );
+            }
+
             $question = new ChoiceQuestion(
                 'Please choose a role: ',
                 $roles,


### PR DESCRIPTION
If the command does not find any roles, it falls into an infinite loop and does not provide any extra information about what's wrong. This fix solves that problem.

|       Q         |                        A                         |
| -------------- |:------------------------------------------------|
| Tests pass? | none |
| Fixed tickets  | none                                     |
| BC Breaks    | none                              |
| Doc    | none                              |
