### PR TITLE
[HOTFIX] Resolve configuration parameter

### DIFF
--- a/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/Compiler/HandlerPass.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/Compiler/HandlerPass.php
@@ -88,7 +88,7 @@ class HandlerPass implements CompilerPassInterface
     {
         /** @var Definition */
         $definition = $container->getDefinition($id);
-        $reflection = new \ReflectionClass($definition->getClass());
+        $reflection = new \ReflectionClass($container->getParameterBag()->resolveValue($definition->getClass()));
 
         if (!$reflection->implementsInterface('Sulu\Component\HttpCache\HandlerInterface')) {
             throw new \InvalidArgumentException(sprintf(


### PR DESCRIPTION
In the cache handler pass we get the class of the service definition, however this is a parameter name and it needs to be resolved to a class name.