### PR TITLE
[HOTFIX] Incorrect event name used for HTTP cache invalidator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 CHANGELOG for Sulu
 ==================
+
+    * HOTFIX      #781 [CoreBundle]     HTTP Cache event listener uses the wrong event name due to recent change
     * HOTFIX      #741 [ContentBundle]  Fix Resourcelocater Content Type call move without editing
 
 * 0.14.1 (2015-01-21)

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/http-cache.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/http-cache.xml
@@ -25,7 +25,7 @@
 
         <!-- content node event listener -->
         <service id="sulu.http_cache.event_listener.content_node" class="%sulu.http_cache.event_listener.content_node.class%">
-            <tag name="kernel.event_listener" event="sulu.content.node.save" method="onContentNodeSave"/>
+            <tag name="kernel.event_listener" event="sulu.content.node.post_save" method="onContentNodeSave"/>
             <argument type="service" id="sulu.http_cache.http_cache_manager"/>
             <argument>%kernel.environment%</argument>
         </service>


### PR DESCRIPTION
The incorrect event name was being used for the invalidator due to a recent change.