### PR TITLE
Fixed bug with empty selection with single internal link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * HOTFIX      #788 [ContentBundle]  Fixed bug with empty selection with single internal link
+
 * 0.14.2 (2015-02-02)
     * HOTFIX      #781 [CoreBundle]     HTTP Cache event listener uses the wrong event name due to recent change
 

--- a/src/Sulu/Bundle/ContentBundle/Content/Types/SingleInternalLink.php
+++ b/src/Sulu/Bundle/ContentBundle/Content/Types/SingleInternalLink.php
@@ -41,17 +41,11 @@ class SingleInternalLink extends SimpleContentType
         $segmentKey
     ) {
         $value = $property->getValue();
-<<<<<<< Updated upstream
-        if ($value !== $node->getIdentifier()) {
-            parent::write($node, $property, $userId, $webspaceKey, $languageCode,$segmentKey);
+        if ($node->getIdentifier() !== null && $value !== $node->getIdentifier()) {
+            parent::write($node, $property, $userId, $webspaceKey, $languageCode, $segmentKey);
         } else {
             // FIXME validation and an own exception in sulu/sulu
             throw new \Exception();
-=======
-
-        if ($node->getIdentifier() !== null && $value === $node->getIdentifier()) {
-            throw new \InvalidArgumentException('Internal link node cannot reference itself');
->>>>>>> Stashed changes
         }
     }
 

--- a/src/Sulu/Bundle/ContentBundle/Content/Types/SingleInternalLink.php
+++ b/src/Sulu/Bundle/ContentBundle/Content/Types/SingleInternalLink.php
@@ -39,14 +39,19 @@ class SingleInternalLink extends SimpleContentType
         $webspaceKey,
         $languageCode,
         $segmentKey
-    )
-    {
+    ) {
         $value = $property->getValue();
+<<<<<<< Updated upstream
         if ($value !== $node->getIdentifier()) {
             parent::write($node, $property, $userId, $webspaceKey, $languageCode,$segmentKey);
         } else {
             // FIXME validation and an own exception in sulu/sulu
             throw new \Exception();
+=======
+
+        if ($node->getIdentifier() !== null && $value === $node->getIdentifier()) {
+            throw new \InvalidArgumentException('Internal link node cannot reference itself');
+>>>>>>> Stashed changes
         }
     }
 

--- a/src/Sulu/Bundle/ContentBundle/Content/Types/SingleInternalLink.php
+++ b/src/Sulu/Bundle/ContentBundle/Content/Types/SingleInternalLink.php
@@ -41,7 +41,7 @@ class SingleInternalLink extends SimpleContentType
         $segmentKey
     ) {
         $value = $property->getValue();
-        if ($node->getIdentifier() !== null && $value !== $node->getIdentifier()) {
+        if ($node->getIdentifier() === null || $value !== $node->getIdentifier()) {
             parent::write($node, $property, $userId, $webspaceKey, $languageCode, $segmentKey);
         } else {
             // FIXME validation and an own exception in sulu/sulu


### PR DESCRIPTION
__Tasks:__

- [x] gather feedback for my changes
- [x] added changelog line


__Informations:__

| Q             | A
| ------------- | ---
| Tests pass?   | yes
| Fixed tickets | none
| BC Breaks     | none
| Doc           | none