### PR TITLE
[BUGFIX] reversed structure paths

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/DependencyInjection/SuluContentExtension.php
+++ b/src/Sulu/Bundle/ContentBundle/DependencyInjection/SuluContentExtension.php
@@ -32,7 +32,7 @@ class SuluContentExtension extends Extension implements PrependExtensionInterfac
                 'content' => array(
                     'structure' => array(
                         'paths' => array(
-                            'sulu_content_bundle' => array(
+                            array(
                                 'path' => __DIR__ . '/../Content/templates',
                                 'type' => 'page',
                                 'internal' => true,

--- a/src/Sulu/Component/Content/StructureManager.php
+++ b/src/Sulu/Component/Content/StructureManager.php
@@ -91,6 +91,9 @@ class StructureManager extends ContainerAware implements StructureManagerInterfa
 
         // overwrite the default values with the given options
         $this->options = array_merge($defaultOptions, $options);
+
+        // FIXME find better solution for default templates in bundle
+        $this->options['structure_paths'] = array_reverse($this->options['structure_paths']);
     }
 
     /**


### PR DESCRIPTION
this needs to be done, because otherwise default configs can not be overwritten by other bundles in other webspaces. this issue occurred because it was no longer possible to user an other excerpt.xml defined in the configs.