### PR TITLE
Added default values for smart content view vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG for Sulu
     * ENHANCEMENT #818 [ContentBundle]   Enhanced column-navigation ordering ui
     * BUGFIX      #857 [ContentBundle]   Added links without save could not be removed
     * FEATURE     #789 [ContentBundle]   Added present as to smart content config (see [here ...](https://github.com/sulu-cmf/docs/blob/master/developer-documentation/300-webspaces/smart-content.md))
+    * BUGFIX      #856 [ContentBundle]   Added default values for smart content view vars
 
 * 0.15.2 (2915-02-19)
     * HOTFIX      #850 [MediaBundle]     Fixed bug with deleted media in media selection

--- a/src/Sulu/Bundle/ContentBundle/Content/Types/SmartContent/SmartContent.php
+++ b/src/Sulu/Bundle/ContentBundle/Content/Types/SmartContent/SmartContent.php
@@ -201,7 +201,7 @@ class SmartContent extends ComplexContentType
                 'dataSource' => null,
                 'includeSubFolders' => null,
                 'category' => null,
-                'tags' => null,
+                'tags' => array(),
                 'sortBy' => null,
                 'sortMethod' => null,
                 'presentAs' => null,

--- a/src/Sulu/Bundle/ContentBundle/Content/Types/SmartContent/SmartContent.php
+++ b/src/Sulu/Bundle/ContentBundle/Content/Types/SmartContent/SmartContent.php
@@ -18,8 +18,8 @@ use Sulu\Component\Content\PropertyInterface;
 use Sulu\Component\Content\PropertyParameter;
 use Sulu\Component\Content\Query\ContentQueryBuilderInterface;
 use Sulu\Component\Content\Query\ContentQueryExecutorInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Sulu\Component\Util\ArrayableInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Stopwatch\Stopwatch;
 
 /**
@@ -195,6 +195,22 @@ class SmartContent extends ComplexContentType
     {
         $this->getContentData($property);
         $config = $property->getValue();
+
+        $config = array_merge(
+            array(
+                'dataSource' => null,
+                'includeSubFolders' => null,
+                'category' => null,
+                'tags' => null,
+                'sortBy' => null,
+                'sortMethod' => null,
+                'presentAs' => null,
+                'limitResult' => null,
+                'page' => null,
+                'hasNextPage' => null,
+            ),
+            $config
+        );
 
         return $config;
     }

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Content/Types/SmartContent/SmartContentTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Content/Types/SmartContent/SmartContentTest.php
@@ -578,7 +578,7 @@ class SmartContentTest extends \PHPUnit_Framework_TestCase
                     'dataSource' => null,
                     'includeSubFolders' => null,
                     'category' => null,
-                    'tags' => null,
+                    'tags' => array(),
                     'sortBy' => null,
                     'sortMethod' => null,
                     'presentAs' => null,

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Content/Types/SmartContent/SmartContentTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Content/Types/SmartContent/SmartContentTest.php
@@ -389,7 +389,7 @@ class SmartContentTest extends \PHPUnit_Framework_TestCase
 
         $viewData = $this->smartContent->getViewData($property);
 
-        $this->assertEquals(array_merge($config, array('page' => 1, 'hasNextPage' => true)), $viewData);
+        $this->assertContains(array_merge($config, array('page' => 1, 'hasNextPage' => true)), $viewData);
     }
 
     public function testGetContentData()
@@ -572,7 +572,24 @@ class SmartContentTest extends \PHPUnit_Framework_TestCase
         $structure->expects($this->any())->method('getUuid')->will($this->returnValue($uuid));
 
         $viewData = $this->smartContent->getViewData($property);
-        $this->assertEquals(array_merge($config, array('page' => $page, 'hasNextPage' => $hasNextPage)), $viewData);
+        $this->assertEquals(
+            array_merge(
+                array(
+                    'dataSource' => null,
+                    'includeSubFolders' => null,
+                    'category' => null,
+                    'tags' => null,
+                    'sortBy' => null,
+                    'sortMethod' => null,
+                    'presentAs' => null,
+                    'limitResult' => null,
+                    'page' => null,
+                    'hasNextPage' => null,
+                ),
+                $config,
+                array('page' => $page, 'hasNextPage' => $hasNextPage)
+            ),
+            $viewData);
     }
 
     private function getContentDataProperty()


### PR DESCRIPTION
__Tasks:__

- [ ] gather feedback for my changes
- [x] added changelog line

__Informations:__

| Q             | A
| ------------- | ---
| Tests pass?   | yes
| Fixed tickets | none
| BC Breaks     | none
| Doc           | https://github.com/sulu-cmf/docs/commit/040257e43fc7d50d5c8b8f571278caffb811974c