### PR TITLE
Wait for username to appear on login screen

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Behat/SecurityContext.php
+++ b/src/Sulu/Bundle/SecurityBundle/Behat/SecurityContext.php
@@ -96,6 +96,7 @@ class SecurityContext extends BaseContext implements SnippetAcceptingContext
         $this->theUserExistsWithPassword('admin', 'admin');
         $this->visitPath('/admin');
         $page = $this->getSession()->getPage();
+        $this->waitForSelector('#username');
         $this->fillSelector('#username', 'admin');
         $this->fillSelector('#password', 'admin');
         $loginButton = $page->findById('login-button');


### PR DESCRIPTION
In the behat tests the login screen no longer seems to contain the HTML form when the DOM is ready.

This fix waits for the `#username` selector to appear before filling the form in.