### PR TITLE
Send 200 instead of 404 in HTTP cache

### DIFF
--- a/src/Sulu/Component/HttpCache/HttpCache.php
+++ b/src/Sulu/Component/HttpCache/HttpCache.php
@@ -50,7 +50,7 @@ class HttpCache extends HttpCacheAbstract
         if ($this->getStore()->purge($request->getUri())) {
             $response->setStatusCode(200, 'Purged');
         } else {
-            $response->setStatusCode(404, 'Not purged');
+            $response->setStatusCode(200, 'Not purged');
         }
 
         return $response;


### PR DESCRIPTION
Do not send a 404 on purge when the (Sulu) HTTP cache does not find a cached page to purge.